### PR TITLE
feat: update manifests command to write CRDs to disk

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run: cargo build
       - name: Generate
-        run: cargo run -- manifests
+        run: cargo run -- manifests --crd-dir config/crd/bases
       - name: Diff
         run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
       - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run: cargo build
       - name: Generate
-        run: cargo run -- manifests > config/crd/bases/kubecfg.dev_appinstances.yaml
+        run: cargo run -- manifests
       - name: Diff
         run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
       - name: Run tests

--- a/config/crd/bases/kubecfg.dev_appinstances.yaml
+++ b/config/crd/bases/kubecfg.dev_appinstances.yaml
@@ -57,4 +57,3 @@ spec:
     storage: true
     subresources:
       status: {}
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ async fn main() -> anyhow::Result<()> {
     match &command {
         Some(Commands::Manifests { crd_dir }) => match crd_dir {
             Some(crd_dir) => {
+                // Expand vector as more CRDs are created.
                 for crd in vec![&kubit::resources::AppInstance::crd()] {
                     let crd_path = format!(
                         "{}/{}_{}.yaml",

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,22 +52,19 @@ async fn main() -> anyhow::Result<()> {
     } = Args::parse();
 
     match &command {
-        Some(Commands::Manifests { crd_dir }) => {
-            match crd_dir {
-                Some(crd_dir) => {
-                    let crd_path = format!("{}/{}", crd_dir, kubit::resources::APPINSTANCE_CRD_FILE);
+        Some(Commands::Manifests { crd_dir }) => match crd_dir {
+            Some(crd_dir) => {
+                let crd_path = format!("{}/{}", crd_dir, kubit::resources::APPINSTANCE_CRD_FILE);
 
-                    let file = File::create(crd_path)
-                        .expect("Could not open AppInstances CRD file");
+                let file = File::create(crd_path).expect("Could not open AppInstances CRD file");
 
-                    serde_yaml::to_writer(&file, &kubit::resources::AppInstance::crd())?;
-                }
-                None => println!(
-                    "{}",
-                    serde_yaml::to_string(&kubit::resources::AppInstance::crd()).unwrap(),
-                ),
+                serde_yaml::to_writer(&file, &kubit::resources::AppInstance::crd())?;
             }
-        }
+            None => println!(
+                "{}",
+                serde_yaml::to_string(&kubit::resources::AppInstance::crd()).unwrap(),
+            ),
+        },
         None => {
             let mut admin = kubert::admin::Builder::from(admin);
             admin.with_default_prometheus();

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,17 @@ async fn main() -> anyhow::Result<()> {
     match &command {
         Some(Commands::Manifests { crd_dir }) => match crd_dir {
             Some(crd_dir) => {
-                let crd_path = format!("{}/{}", crd_dir, kubit::resources::APPINSTANCE_CRD_FILE);
+                for crd in vec![&kubit::resources::AppInstance::crd()] {
+                    let crd_path = format!(
+                        "{}/{}_{}.yaml",
+                        crd_dir, crd.spec.group, crd.spec.names.plural
+                    );
 
-                let file = File::create(crd_path).expect("Could not open AppInstances CRD file");
+                    let file =
+                        File::create(crd_path).expect("Could not open AppInstances CRD file");
 
-                serde_yaml::to_writer(&file, &kubit::resources::AppInstance::crd())?;
+                    serde_yaml::to_writer(&file, &kubit::resources::AppInstance::crd())?;
+                }
             }
             None => println!(
                 "{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 
-use std::fs::File;
+use std::{fs::File, path::PathBuf};
 
 use clap::{Parser, Subcommand};
 use kube::CustomResourceExt;
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
                 long,
                 help = "Optional directory to write CRDs into, otherwise write to stdout"
             )]
-            crd_dir: Option<String>,
+            crd_dir: Option<PathBuf>,
         },
     }
 
@@ -56,10 +56,8 @@ async fn main() -> anyhow::Result<()> {
             Some(crd_dir) => {
                 // Expand vector as more CRDs are created.
                 for crd in vec![&kubit::resources::AppInstance::crd()] {
-                    let crd_path = format!(
-                        "{}/{}_{}.yaml",
-                        crd_dir, crd.spec.group, crd.spec.names.plural
-                    );
+                    let crd_file = format!("{}_{}.yaml", crd.spec.group, crd.spec.names.plural);
+                    let crd_path = PathBuf::from(crd_dir).join(crd_file);
 
                     let file =
                         File::create(crd_path).expect("Could not open AppInstances CRD file");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 
-use std::fs::OpenOptions;
+use std::fs::File;
 
 use clap::{Parser, Subcommand};
 use kube::CustomResourceExt;
@@ -33,7 +33,14 @@ async fn main() -> anyhow::Result<()> {
     #[derive(Clone, Subcommand)]
     enum Commands {
         /// Generates k8s manifests
-        Manifests,
+        Manifests {
+            // Optional directory to write CRDs into
+            #[clap(
+                long,
+                help = "Optional directory to write CRDs into, otherwise write to stdout"
+            )]
+            crd_dir: Option<String>,
+        },
     }
 
     let Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,14 +52,21 @@ async fn main() -> anyhow::Result<()> {
     } = Args::parse();
 
     match &command {
-        Some(Commands::Manifests) => {
-            let f = OpenOptions::new()
-                .write(true)
-                .open(kubit::resources::APPINSTANCE_CRD_PATH)
-                .expect("Could not open AppInstances CRD file");
+        Some(Commands::Manifests { crd_dir }) => {
+            match crd_dir {
+                Some(crd_dir) => {
+                    let crd_path = format!("{}/{}", crd_dir, kubit::resources::APPINSTANCE_CRD_FILE);
 
-            serde_yaml::to_writer(&f, &kubit::resources::AppInstance::crd()).unwrap();
+                    let file = File::create(crd_path)
+                        .expect("Could not open AppInstances CRD file");
 
+                    serde_yaml::to_writer(&file, &kubit::resources::AppInstance::crd())?;
+                }
+                None => println!(
+                    "{}",
+                    serde_yaml::to_string(&kubit::resources::AppInstance::crd()).unwrap(),
+                ),
+            }
         }
         None => {
             let mut admin = kubert::admin::Builder::from(admin);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 
+use std::fs::OpenOptions;
+
 use clap::{Parser, Subcommand};
 use kube::CustomResourceExt;
 
@@ -44,10 +46,13 @@ async fn main() -> anyhow::Result<()> {
 
     match &command {
         Some(Commands::Manifests) => {
-            println!(
-                "{}",
-                serde_yaml::to_string(&kubit::resources::AppInstance::crd()).unwrap(),
-            );
+            let f = OpenOptions::new()
+                .write(true)
+                .open(kubit::resources::APPINSTANCE_CRD_PATH)
+                .expect("Could not open AppInstances CRD file");
+
+            serde_yaml::to_writer(&f, &kubit::resources::AppInstance::crd()).unwrap();
+
         }
         None => {
             let mut admin = kubert::admin::Builder::from(admin);

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -4,7 +4,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const APPINSTANCE_CRD_PATH: &str = "config/crd/bases/kubecfg.dev_appinstances.yaml";
+pub const APPINSTANCE_CRD_FILE: &str = "kubecfg.dev_appinstances.yaml";
 
 #[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[kube(

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -4,8 +4,6 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const APPINSTANCE_CRD_FILE: &str = "kubecfg.dev_appinstances.yaml";
-
 #[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[kube(
     group = "kubecfg.dev",

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -4,6 +4,8 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+pub const APPINSTANCE_CRD_PATH: &str = "config/crd/bases/kubecfg.dev_appinstances.yaml";
+
 #[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[kube(
     group = "kubecfg.dev",


### PR DESCRIPTION
Building from https://github.com/kubecfg/kubit/pull/7#discussion_r1273617933

This writes the `AppInstance` CRD directly into the file, meaning we can simply update the manifests with `cargo run -- manifests`.

---

### Example
```rust
// src/resources.rs
pub struct AppInstanceSpec {
    pub package: Package,
    pub test: String, // adding this field
    pub image_pull_secrets: Option<Vec<LocalObjectReference>>,
}
```

And execute `cargo run -- manifests --crd-dir config/crd/bases`, then we see

```
git status --short
 M config/crd/bases/kubecfg.dev_appinstances.yaml
 M src/resources.rs
```

```yaml
# snippet from: config/crd/bases/kubecfg.dev_appinstances.yaml
            required:
            - package
         +  - test
```

When running simply `cargo run -- manifests`, we are writing to `stdout` as before.
