### PR TITLE
feat: Fetch OCI metadata

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use kube::{
     api::ListParams,
@@ -9,13 +9,22 @@ use kube::{
     },
     Api, Client, ResourceExt,
 };
+use oci_distribution::{
+    manifest::OciManifest, secrets::RegistryAuth, Client as OCIClient, Reference,
+};
+use serde::{Deserialize, Serialize};
+use serde_json;
 
 #[allow(unused_imports)]
 use tracing::{debug, error, info, warn};
 
 use crate::{resources::AppInstance, Error, Result};
 
-struct Context {}
+const PACK_KEY: &str = "pack.kubecfg.dev/v1alpha1";
+
+struct Context {
+    kubecfg_image: String,
+}
 
 fn error_policy(sinker: Arc<AppInstance>, error: &Error, _ctx: Arc<Context>) -> Action {
     let name = sinker.name_any();
@@ -24,7 +33,7 @@ fn error_policy(sinker: Arc<AppInstance>, error: &Error, _ctx: Arc<Context>) -> 
     Action::requeue(Duration::from_secs(5))
 }
 
-pub async fn run(client: Client) -> Result<()> {
+pub async fn run(client: Client, kubecfg_image: String) -> Result<()> {
     let docs = Api::<AppInstance>::all(client.clone());
     if let Err(e) = docs.list(&ListParams::default().limit(1)).await {
         error!("CRD is not queryable; {e:?}. Is the CRD installed?");
@@ -32,7 +41,7 @@ pub async fn run(client: Client) -> Result<()> {
     }
     Controller::new(docs, watcher::Config::default().any_semantic())
         .shutdown_on_signal()
-        .run(reconcile, error_policy, Arc::new(Context {}))
+        .run(reconcile, error_policy, Arc::new(Context { kubecfg_image }))
         .filter_map(|x| async move { std::result::Result::ok(x) })
         .for_each(|_| futures::future::ready(()))
         .await;
@@ -40,7 +49,65 @@ pub async fn run(client: Client) -> Result<()> {
     Ok(())
 }
 
-async fn reconcile(app_instance: Arc<AppInstance>, _ctx: Arc<Context>) -> Result<Action> {
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PackageConfig {
+    entrypoint: String,
+    #[serde(default)]
+    metadata: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KubecfgPackageMetadata {
+    version: String,
+}
+
+async fn reconcile(app_instance: Arc<AppInstance>, ctx: Arc<Context>) -> Result<Action> {
     info!(?app_instance, "running reconciler");
+
+    let image = &app_instance.spec.package.image;
+    info!(image, "fetching image");
+
+    let reference: Reference = image.parse()?;
+
+    let client_config = oci_distribution::client::ClientConfig {
+        protocol: oci_distribution::client::ClientProtocol::Https,
+        ..Default::default()
+    };
+    let mut client = OCIClient::new(client_config);
+    let (manifest, _) = client
+        .pull_manifest(&reference, &RegistryAuth::Anonymous)
+        .await?;
+
+    let manifest = match manifest {
+        OciManifest::Image(manifest) => manifest,
+        OciManifest::ImageIndex(_) => return Err(Error::UnsupportedManifestIndex),
+    };
+
+    let mut buf = vec![];
+    client
+        .pull_blob(&reference, &manifest.config.digest, &mut buf)
+        .await?;
+
+    let config: PackageConfig = serde_json::from_slice(&buf).map_err(Error::DecodePackageConfig)?;
+    info!(?config, "got package config");
+
+    let kubecfg_pack_metadata: KubecfgPackageMetadata =
+        serde_json::from_value(config.metadata.get(PACK_KEY).unwrap().clone())
+            .map_err(Error::DecodeKubecfgPackageMetadata)?;
+
+    let kubecfg_version = &kubecfg_pack_metadata.version;
+    let kubecfg_image = format!("{}:{kubecfg_version}", ctx.kubecfg_image);
+    let entrypoint = format!("oci://{reference}");
+    let overlay_spec =
+        serde_json::to_string(&app_instance.spec.package.spec).map_err(Error::RenderSpec)?;
+    info!(
+        ?kubecfg_image,
+        entrypoint,
+        overlay_spec,
+        "TODO: create a Job that runs kubecfg and renders the jsonnet artifact"
+    );
+
     Ok(Action::await_change())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,24 @@
 pub enum Error {
     #[error("Kube Error: {0}")]
     KubeError(#[from] kube::Error),
+
+    #[error("OCI error: {0}")]
+    OCIParseError(#[from] oci_distribution::ParseError),
+
+    #[error("OCI error: {0}")]
+    OCIError(#[from] oci_distribution::errors::OciDistributionError),
+
+    #[error("Unsupported manifest type: Index")]
+    UnsupportedManifestIndex,
+
+    #[error("Error decoding package config JSON: {0}")]
+    DecodePackageConfig(serde_json::Error),
+
+    #[error("Error decoding kubecfg pack metadata JSON: {0}")]
+    DecodeKubecfgPackageMetadata(serde_json::Error),
+
+    #[error("Error rendering spec back as JSON: {0}")]
+    RenderSpec(serde_json::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ async fn main() -> anyhow::Result<()> {
         #[clap(flatten)]
         admin: kubert::AdminArgs,
 
+        #[clap(long, default_value = "ghcr.io/kubecfg/kubecfg/kubecfg")]
+        kubecfg_image: String,
+
         #[command(subcommand)]
         command: Option<Commands>,
     }
@@ -48,6 +51,7 @@ async fn main() -> anyhow::Result<()> {
         log_format,
         client,
         admin,
+        kubecfg_image,
         command,
     } = Args::parse();
 
@@ -81,7 +85,7 @@ async fn main() -> anyhow::Result<()> {
                 .build()
                 .await?;
 
-            let controller = controller::run(rt.client());
+            let controller = controller::run(rt.client(), kubecfg_image);
 
             // Both runtimes implements graceful shutdown, so poll until both are done
             tokio::join!(controller, rt.run()).1?;


### PR DESCRIPTION
Fetches the OCI artifact manifests and parses the config created by `kubecfg pack`.

It doesn't do anything yet with the info and it only handles unauthenticated repo.