### PR TITLE
refactor: unify code path for `--crd-dir` flag, writing to a `File` and `stdout`

### DIFF
--- a/config/crd/bases/kubecfg.dev_appinstances.yaml
+++ b/config/crd/bases/kubecfg.dev_appinstances.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
                     None => Box::new(stdout()),
                 };
                 // The YAML delimiter is added in the event we have multiple documents.
-                out_writer.write(b"---\n").unwrap();
+                writeln!(out_writer, "---").unwrap();
                 serde_yaml::to_writer(out_writer, &crd).unwrap();
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,15 +64,14 @@ async fn main() -> anyhow::Result<()> {
     match &command {
         Some(Commands::Manifests { crd_dir }) => {
             for crd in crds {
-                let mut out_writer = match crd_dir {
+                let mut out_writer: Box<dyn Write> = match crd_dir {
                     Some(dir) => {
                         let crd_file = format!("{}_{}.yaml", crd.spec.group, crd.spec.names.plural);
-                        let crd_path = PathBuf::from(dir).join(crd_file);
-                        let file =
-                            File::create(crd_path).expect("Could not open AppInstances CRD file");
-                        Box::new(file) as Box<dyn Write>
+                        let file = File::create(dir.join(crd_file))
+                            .expect("Could not open AppInstances CRD file");
+                        Box::new(file)
                     }
-                    None => Box::new(stdout()) as Box<dyn Write>,
+                    None => Box::new(stdout()),
                 };
                 // The YAML delimiter is added in the event we have multiple documents.
                 out_writer.write(b"---\n").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,11 +51,12 @@ async fn main() -> anyhow::Result<()> {
         command,
     } = Args::parse();
 
+    // Expand vector as more CRDs are created.
+    let crds = vec![kubit::resources::AppInstance::crd()];
     match &command {
         Some(Commands::Manifests { crd_dir }) => match crd_dir {
             Some(crd_dir) => {
-                // Expand vector as more CRDs are created.
-                for crd in vec![&kubit::resources::AppInstance::crd()] {
+                for crd in crds {
                     let crd_file = format!("{}_{}.yaml", crd.spec.group, crd.spec.names.plural);
                     let crd_path = PathBuf::from(crd_dir).join(crd_file);
 
@@ -65,10 +66,11 @@ async fn main() -> anyhow::Result<()> {
                     serde_yaml::to_writer(&file, &kubit::resources::AppInstance::crd())?;
                 }
             }
-            None => println!(
-                "{}",
-                serde_yaml::to_string(&kubit::resources::AppInstance::crd()).unwrap(),
-            ),
+            None => {
+                for crd in crds {
+                    println!("{}---\n", serde_yaml::to_string(&crd).unwrap(),);
+                }
+            }
         },
         None => {
             let mut admin = kubert::admin::Builder::from(admin);

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
             None => {
                 for crd in crds {
                     // The YAML delimiter is added in the event we have multiple documents.
-                    println!("---{}", serde_yaml::to_string(&crd).unwrap(),);
+                    println!("---{}", serde_yaml::to_string(&crd).unwrap());
                 }
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,8 @@ async fn main() -> anyhow::Result<()> {
             }
             None => {
                 for crd in crds {
-                    println!("{}---\n", serde_yaml::to_string(&crd).unwrap(),);
+                    // The YAML delimiter is added in the event we have multiple documents.
+                    println!("---{}", serde_yaml::to_string(&crd).unwrap(),);
                 }
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
     match &command {
         Some(Commands::Manifests { crd_dir }) => {
             for crd in crds {
-                let out_writer = match crd_dir {
+                let mut out_writer = match crd_dir {
                     Some(dir) => {
                         let crd_file = format!("{}_{}.yaml", crd.spec.group, crd.spec.names.plural);
                         let crd_path = PathBuf::from(dir).join(crd_file);
@@ -70,6 +70,8 @@ async fn main() -> anyhow::Result<()> {
                     }
                     None => Box::new(stdout()) as Box<dyn Write>,
                 };
+                // The YAML delimiter is added in the event we have multiple documents.
+                out_writer.write(b"---\n").unwrap();
                 serde_yaml::to_writer(out_writer, &crd).unwrap();
             }
         }


### PR DESCRIPTION
At the moment, if we run the `manifests` command, this is tied entirely to only our `AppInstance` CRD. This is being changed so that we have a single place to reference the CRDs (within the outer `vec!` macro), these can be updated as we add CRDs.

We're adding the YAML delimiter (`---`) to signify that there may be multiple documents.
