### PR TITLE
feat: CLI commands to preview the generated scripts

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,0 +1,10 @@
+use crate::{resources::AppInstance, Result};
+
+/// Generates shell script that will apply the manifests
+pub fn emit_script<W>(_app_instance: &AppInstance, w: &mut W) -> Result<()>
+where
+    W: std::io::Write,
+{
+    writeln!(w, "echo TODO")?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub enum Error {
 
     #[error("Error rendering spec back as JSON: {0}")]
     RenderSpec(serde_json::Error),
+
+    #[error("IO Error: {0}")]
+    IOError(#[from] std::io::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -31,3 +34,6 @@ pub mod controller;
 
 /// Resource type definitions.
 pub mod resources;
+
+pub mod apply;
+pub mod render;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,10 @@
+use crate::{resources::AppInstance, Result};
+
+/// Generates shell script that will render the manifest
+pub fn emit_script<W>(_app_instance: &AppInstance, w: &mut W) -> Result<()>
+where
+    W: std::io::Write,
+{
+    writeln!(w, "echo TODO")?;
+    Ok(())
+}


### PR DESCRIPTION
The operator will spawn a job that will run some template engine (like `kubecfg`) to render some manifests and then run some tool (likely `kubectl`) to apply the manifests.

I'd like to be able to easily inspect those commands offline instead of having to run the operator for real and peek at the pods to see what is the exact script that has been run. This will help us iterate quickly on this tool

"demo":

```console
$ ./target/debug/kubit scripts --app-instance examples/demo.yaml render
echo TODO
$ ./target/debug/kubit scripts --app-instance examples/demo.yaml apply 
echo TODO
```

doesn't do much yet