### PR TITLE
fix: Add x-kubernetes-preserve-unknown-fields

### DIFF
--- a/config/crd/bases/kubecfg.dev_appinstances.yaml
+++ b/config/crd/bases/kubecfg.dev_appinstances.yaml
@@ -37,8 +37,8 @@ spec:
                   image:
                     type: string
                   spec:
-                    additionalProperties: true
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - apiVersion
                 - image

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use kube::CustomResource;
-use schemars::JsonSchema;
+use schemars::{
+    schema::{Schema, SchemaObject},
+    JsonSchema,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
@@ -30,7 +33,22 @@ pub struct LocalObjectReference {
 pub struct Package {
     pub image: String,
     pub api_version: String,
-    pub spec: HashMap<String, serde_json::Value>,
+    pub spec: PackageSpec,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageSpec {
+    #[serde(flatten)]
+    #[schemars(schema_with = "preserve_arbitrary")]
+    arbitrary: HashMap<String, serde_json::Value>,
+}
+
+fn preserve_arbitrary(_gen: &mut schemars::gen::SchemaGenerator) -> Schema {
+    let mut obj = SchemaObject::default();
+    obj.extensions
+        .insert("x-kubernetes-preserve-unknown-fields".into(), true.into());
+    Schema::Object(obj)
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]


### PR DESCRIPTION
I misunderstood what schema would k8s accept for arbitrary subtree.

Turns out we need `x-kubernetes-preserve-unknown-fields`

```yaml
apiVersion: v1
items:
- apiVersion: kubecfg.dev/v1alpha1
  kind: AppInstance
  metadata:
    creationTimestamp: "2023-07-27T15:29:52Z"
    generation: 4
    name: influxdb
    namespace: influxdb
    resourceVersion: "5036"
    uid: 74f45619-593d-4122-85dd-136ca96c027d
  spec:
    imagePullSecrets:
    - name: gar-docker-secret
    package:
      apiVersion: influxdata.com/v1alpha1
      image: oci.influxdata.com/influxdb:20230718
      spec:
        catalog: {}
        images: {}
        ingesterStorage: {}
        ingress: {}
        objectStore: {}
kind: List
metadata:
  resourceVersion: ""
```

funny enough, once we fix the CRD, the apiserver re-surfaces the fields without having to reapply the reource! the fields weren't lost:

```yaml
apiVersion: v1
items:
- apiVersion: kubecfg.dev/v1alpha1
  kind: AppInstance
  metadata:
    creationTimestamp: "2023-07-27T16:19:41Z"
    generation: 2
    name: influxdb
    namespace: influxdb
    resourceVersion: "5336"
    uid: 9737fa68-b2da-4c29-a84a-ce54d47ac745
  spec:
    imagePullSecrets:
    - name: gar-docker-secret
    package:
      apiVersion: influxdata.com/v1alpha1
      image: us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:20230727-503750
      spec:
        catalog:
          dsn:
            valueFrom:
              secretKeyRef:
                key: dsn
                name: catalog-db
        images:
          overrides:
          - name: influxdb2-artifacts/iox/iox
            newFQIN: mkmik/iox@sha256:739886c1d977546016487ca82a7295620e56be66a7d232a64ce641d80ef93456
        ingesterStorage:
          storage: 1Gi
          storageClassName: local-path
        ingress:
          className: traefik
        objectStore:
          accessKey:
            value: minioadmin
          allowHttp: "true"
          bucket: influxdb
          endpoint: http://minio-s3.influxdb.svc.cluster.local
          region: local
          secretKey:
            value: minioadmin
kind: List
metadata:
  resourceVersion: ""
```