### PR TITLE
feat: render manifests via `kubecfg`

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -223,7 +223,7 @@ async fn launch_job(
                     ]),
                     restart_policy: Some("Never".to_string()),
                     containers: vec![Container {
-                        name: "kubecfg-render".to_string(),
+                        name: "kubecfg-show".to_string(),
                         image: Some(kubecfg_image.clone()),
                         env: Some(vec![EnvVar {
                             name: "DOCKER_CONFIG".to_string(),

--- a/src/render.rs
+++ b/src/render.rs
@@ -31,7 +31,8 @@ pub fn emit_commandline(app_instance: &AppInstance, overlay_file: &str) -> Vec<S
         "kubecfg",
         "show",
         "--alpha",
-        image,
+        "--reorder=server",
+        &format!("oci://{}", image),
         "--overlay-code-file",
         &format!("appInstance_={overlay_file}"),
     ]


### PR DESCRIPTION
The intention here is that the `kubecfg` step will be an `initContainer` (not done yet) which will render our given OCI bundle, which contains manifests. 

Eventually it will write the manifests into a file. This file will be accessible to the (currently non-existent) `apply` step as it will have been written to an `emptyDir` that is shared by the `Job`.
