### PR TITLE
Follow the job, capture the logs, delete the job, and repeat

### DIFF
--- a/config/crd/bases/kubecfg.dev_appinstances.yaml
+++ b/config/crd/bases/kubecfg.dev_appinstances.yaml
@@ -49,6 +49,12 @@ spec:
             type: object
           status:
             nullable: true
+            properties:
+              lastLogs:
+                additionalProperties:
+                  type: string
+                nullable: true
+                type: object
             type: object
         required:
         - spec

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -31,6 +31,8 @@ pub fn emit_commandline(app_instance: &AppInstance, manifests_dir: &str) -> Vec<
         "--applyset",
         &app_instance.name_any(),
         "--force-conflicts",
+        "-v",
+        "2",
     ]
     .iter()
     .map(|s| s.to_string())

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -4,20 +4,20 @@ use k8s_openapi::{
     api::{
         batch::v1::{Job, JobSpec},
         core::v1::{
-            Container, EnvVar, KeyToPath, PodSpec, PodTemplateSpec, SecretVolumeSource,
+            Container, EnvVar, KeyToPath, Pod, PodSpec, PodTemplateSpec, SecretVolumeSource,
             ServiceAccount, Volume, VolumeMount,
         },
         rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject},
     },
     apimachinery::pkg::apis::meta::v1::OwnerReference,
 };
-
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use kube::{
-    api::{ListParams, Patch, PatchParams, PostParams},
+    api::{DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams, PropagationPolicy},
     core::ObjectMeta,
     runtime::{
+        conditions::{is_job_completed, Condition},
         controller::{Action, Controller},
         watcher,
     },
@@ -27,12 +27,15 @@ use oci_distribution::{
     manifest::OciManifest, secrets::RegistryAuth, Client as OCIClient, Reference,
 };
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 #[allow(unused_imports)]
 use tracing::{debug, error, info, warn};
 
-use crate::{apply, render, resources::AppInstance, Error, Result};
+use crate::{
+    apply, render,
+    resources::{AppInstance, AppInstanceStatus},
+    Error, Result,
+};
 
 const PACK_KEY: &str = "pack.kubecfg.dev/v1alpha1";
 
@@ -59,8 +62,11 @@ pub async fn run(client: Client, kubecfg_image: String) -> Result<()> {
         error!("CRD is not queryable; {e:?}. Is the CRD installed?");
         std::process::exit(1);
     }
+
+    let jobs = Api::<Job>::all(client.clone());
     Controller::new(docs, watcher::Config::default().any_semantic())
         .shutdown_on_signal()
+        .owns(jobs, watcher::Config::default().any_semantic())
         .run(
             reconcile,
             error_policy,
@@ -90,9 +96,110 @@ struct KubecfgPackageMetadata {
     version: String,
 }
 
-async fn reconcile(app_instance: Arc<AppInstance>, ctx: Arc<Context>) -> Result<Action> {
-    info!(?app_instance, "running reconciler");
+impl PackageConfig {
+    fn kubecfg_package_metadata(&self) -> Result<KubecfgPackageMetadata> {
+        serde_json::from_value(self.metadata.get(PACK_KEY).unwrap().clone())
+            .map_err(Error::DecodeKubecfgPackageMetadata)
+    }
 
+    fn versioned_kubecfg_image(&self, ctx: &Context) -> Result<String> {
+        let kubecfg_version = &self.kubecfg_package_metadata()?.version;
+        Ok(format!("{}:{kubecfg_version}", ctx.kubecfg_image))
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ReconciliationState {
+    Idle,
+    Executing,
+    JobTerminated(String, JobOutcome),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum JobOutcome {
+    Success,
+    Failure,
+}
+
+/// This is the main logic of the controller. This function gets called every time some resource related to the appInstance
+/// changes. This function should be idempotent.
+async fn reconcile(app_instance: Arc<AppInstance>, ctx: Arc<Context>) -> Result<Action> {
+    info!(
+        name = app_instance.name_any(),
+        namespace = app_instance.namespace(),
+        "--------------- Running reconciler ---------------"
+    );
+    // slow down things a little bit
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let state = reconciliation_state(&app_instance, &ctx).await?;
+    info!(?state);
+
+    let action = match state {
+        ReconciliationState::Idle => {
+            launch_job(&app_instance, &ctx).await?;
+            Action::await_change()
+        }
+        ReconciliationState::Executing => {
+            info!(
+                job_name = job_name_for(&app_instance),
+                "waiting for applier job execution"
+            );
+            Action::await_change()
+        }
+        ReconciliationState::JobTerminated(job_uid, outcome) => {
+            let action = match outcome {
+                JobOutcome::Success => {
+                    info!("job completed successfully");
+                    Action::await_change()
+                }
+                JobOutcome::Failure => {
+                    info!("job failed");
+                    Action::requeue(Duration::from_secs(60))
+                }
+            };
+            capture_logs(&app_instance, &ctx, job_uid).await?;
+            delete_job(&app_instance, &ctx).await?;
+            action
+        }
+    };
+
+    Ok(action)
+}
+
+async fn reconciliation_state(
+    app_instance: &AppInstance,
+    ctx: &Context,
+) -> Result<ReconciliationState> {
+    let ns = app_instance.namespace().unwrap();
+    let api: Api<Job> = Api::namespaced(ctx.client.clone(), &ns);
+    let job_name = job_name_for(app_instance);
+    let job = api.get_opt(&job_name).await?;
+
+    Ok(match job {
+        Some(job) => {
+            let uid = job
+                .labels()
+                .get("controller-uid")
+                .expect("Jobs must have controller-uid label")
+                .clone();
+
+            fn condition(job: &Job, cond: impl Condition<Job>) -> bool {
+                cond.matches_object(Some(job))
+            }
+            if condition(&job, is_job_completed()) {
+                ReconciliationState::JobTerminated(uid, JobOutcome::Success)
+            } else if condition(&job, is_job_failed()) {
+                ReconciliationState::JobTerminated(uid, JobOutcome::Failure)
+            } else {
+                ReconciliationState::Executing
+            }
+        }
+        None => ReconciliationState::Idle,
+    })
+}
+
+async fn fetch_package_config(app_instance: &AppInstance) -> Result<PackageConfig> {
     let image = &app_instance.spec.package.image;
     info!(image, "fetching image");
 
@@ -120,18 +227,9 @@ async fn reconcile(app_instance: Arc<AppInstance>, ctx: Arc<Context>) -> Result<
         .pull_blob(&reference, &manifest.config.digest, &mut buf)
         .await?;
 
-    let config: PackageConfig = serde_json::from_slice(&buf).map_err(Error::DecodePackageConfig)?;
-    info!(?config, "got package config");
+    let config = serde_json::from_slice(&buf).map_err(Error::DecodePackageConfig)?;
 
-    let kubecfg_pack_metadata: KubecfgPackageMetadata =
-        serde_json::from_value(config.metadata.get(PACK_KEY).unwrap().clone())
-            .map_err(Error::DecodeKubecfgPackageMetadata)?;
-
-    setup_rbac(&app_instance, Arc::clone(&ctx)).await?;
-
-    launch_job(&app_instance, &kubecfg_pack_metadata, Arc::clone(&ctx)).await?;
-
-    Ok(Action::await_change())
+    Ok(config)
 }
 
 fn handle_resource_exists<R>(res: kube::Result<R>) -> Result<()>
@@ -158,9 +256,13 @@ fn owned_by(app_instance: &AppInstance) -> Option<Vec<OwnerReference>> {
     app_instance.controller_owner_ref(&()).map(|o| vec![o])
 }
 
-async fn setup_rbac(app_instance: &AppInstance, ctx: Arc<Context>) -> Result<()> {
+fn patch_params() -> PatchParams {
+    PatchParams::apply("kubit").force()
+}
+
+async fn setup_job_rbac(app_instance: &AppInstance, ctx: &Context) -> Result<()> {
     let ns = app_instance.clone().namespace().unwrap();
-    let pp = PatchParams::apply("kubit").force();
+    let pp = patch_params();
 
     let metadata = ObjectMeta {
         name: Some(APPLIER_SERVICE_ACCOUNT.to_string()),
@@ -214,18 +316,45 @@ async fn setup_rbac(app_instance: &AppInstance, ctx: Arc<Context>) -> Result<()>
     Ok(())
 }
 
-async fn launch_job(
-    app_instance: &AppInstance,
-    kubecfg_pack_metadata: &KubecfgPackageMetadata,
-    ctx: Arc<Context>,
-) -> Result<()> {
-    let kubecfg_version = &kubecfg_pack_metadata.version;
-    let kubecfg_image = format!("{}:{kubecfg_version}", ctx.kubecfg_image);
+async fn launch_job(app_instance: &AppInstance, ctx: &Context) -> Result<()> {
+    setup_job_rbac(app_instance, ctx).await?;
 
+    let package_config: PackageConfig = fetch_package_config(app_instance).await?;
+    info!(?package_config, "got package config");
+
+    let kubecfg_image = package_config.versioned_kubecfg_image(ctx)?;
     info!("Using: {}", kubecfg_image);
 
+    create_job(app_instance, kubecfg_image, ctx).await
+}
+
+fn job_name_for(app_instance: &AppInstance) -> String {
+    format!("kubit-apply-{}", app_instance.name_any())
+}
+
+async fn delete_job(app_instance: &AppInstance, ctx: &Context) -> Result<()> {
     let ns = &app_instance.namespace().ok_or(Error::NamespaceRequired)?;
-    let job_name = format!("kubit-apply-{}", app_instance.name_any());
+    let jobs: Api<Job> = Api::namespaced(ctx.client.clone(), ns);
+    let name = job_name_for(app_instance);
+    jobs.delete(
+        &name,
+        &DeleteParams {
+            propagation_policy: Some(PropagationPolicy::Foreground),
+            ..Default::default()
+        },
+    )
+    .await?;
+    info!(name, "job deleted");
+    Ok(())
+}
+
+async fn create_job(
+    app_instance: &AppInstance,
+    kubecfg_image: String,
+    ctx: &Context,
+) -> Result<()> {
+    let ns = &app_instance.namespace().ok_or(Error::NamespaceRequired)?;
+    let job_name = job_name_for(app_instance);
 
     let volumes = vec![
         Volume {
@@ -286,7 +415,7 @@ async fn launch_job(
             ..Default::default()
         },
         spec: Some(JobSpec {
-            backoff_limit: Some(1),
+            backoff_limit: Some(0),
             template: PodTemplateSpec {
                 spec: Some(PodSpec {
                     service_account: Some(APPLIER_SERVICE_ACCOUNT.to_string()),
@@ -335,10 +464,112 @@ async fn launch_job(
 
     handle_resource_exists(jobs.create(&pp, &job).await)?;
 
-    // TODO:
-    //
-    // 1. if job exists check if it's has terminated and take action
-    // 2. make sure we watch the job as it changes status
+    Ok(())
+}
 
+// kube crate comes with is_job_completed but that condition is true only if it completes successfully.
+fn is_job_failed() -> impl Condition<Job> {
+    |obj: Option<&Job>| {
+        if let Some(job) = &obj {
+            if let Some(s) = &job.status {
+                if let Some(conds) = &s.conditions {
+                    if let Some(pcond) = conds.iter().find(|c| c.type_ == "Failed") {
+                        return pcond.status == "True";
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
+async fn capture_logs(app_instance: &AppInstance, ctx: &Context, job_uid: String) -> Result<()> {
+    let ns = &app_instance.namespace().ok_or(Error::NamespaceRequired)?;
+    info!(?ns, "reporting errors");
+
+    let pods_api: Api<Pod> = Api::namespaced(ctx.client.clone(), ns);
+    let job_name = job_name_for(app_instance);
+
+    let pods = pods_api
+        .list(&ListParams {
+            label_selector: Some(format!("job-name={job_name},controller-uid={job_uid}")),
+            ..Default::default()
+        })
+        .await?;
+
+    let mut per_container_logs = HashMap::new();
+
+    // There should be exactly one pod per job. In the unlikely even
+    // something is broken with k8s and we end up getting two pods matching the same job uid
+    // let's just get the logs of all these pods and concatenate them together. Chances are
+    // that this is easier to debug than just getting logs for a random pod.
+    //
+    // NOTE(mkm): I don't know how likely this is to happen so I'm not sure if it's worth doing
+    // something more complicated like capturing the pod names and grouping the logs by pod name.
+    for pod in pods.items {
+        let mut container_names = vec![];
+
+        let pod_status = pod.status.as_ref().unwrap();
+        let container_statuses = [
+            pod_status.init_container_statuses.as_ref(),
+            pod_status.container_statuses.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .flat_map(|vec| vec.iter());
+
+        for status in container_statuses {
+            // we cannot get logs from a container that hasn't started yet.
+            // We know a container hasn't started yet when:
+            // 1. the container is explicitly in the "waiting" state
+            // 2. the state field is empty
+            let is_waiting = status
+                .state
+                .as_ref()
+                .map(|x| x.waiting.is_some())
+                .unwrap_or(true);
+            info!(name = status.name, ?is_waiting, "Container status");
+            if !is_waiting {
+                container_names.push(&status.name);
+            }
+        }
+
+        for container_name in container_names {
+            let logs = pods_api
+                .logs(
+                    &pod.name_any(),
+                    &LogParams {
+                        container: Some(container_name.clone()),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            per_container_logs
+                .entry(container_name.clone())
+                .and_modify(|e: &mut String| e.push_str(&logs))
+                .or_insert(logs);
+        }
+        let logs_json =
+            serde_json::to_string(&per_container_logs).expect("cannot render basic json");
+        info!(logs_json);
+    }
+
+    let app_instance_api: Api<AppInstance> = Api::namespaced(ctx.client.clone(), ns);
+
+    let app_instance_patch = AppInstance {
+        metadata: Default::default(),
+        spec: Default::default(),
+        status: Some(AppInstanceStatus {
+            last_logs: Some(per_container_logs),
+        }),
+    };
+    app_instance_api
+        .patch_status(
+            &app_instance.name_any(),
+            &patch_params(),
+            &Patch::Apply(&app_instance_patch),
+        )
+        .await?;
+    info!("status patched");
     Ok(())
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -50,7 +50,5 @@ pub fn emit_fetch_app_instance_script(ns: &str, name: &str, output_file: &str) -
     let ns = quoted(ns);
     let name = quoted(name);
     let output_file = quoted(output_file);
-    format!(
-            "kubectl get appinstances.kubecfg.dev --namespace {ns} {name} -o json >{output_file}; echo rendered ok"
-        )
+    format!("kubectl get appinstances.kubecfg.dev --namespace {ns} {name} -o json >{output_file}")
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -53,4 +53,6 @@ fn preserve_arbitrary(_gen: &mut schemars::gen::SchemaGenerator) -> Schema {
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AppInstanceStatus {}
+pub struct AppInstanceStatus {
+    pub last_logs: Option<HashMap<String, String>>,
+}


### PR DESCRIPTION
This PR implements the basic logic for the applier loop:

1. spawn a job that renders and applies the templates
2. wait until the job has run
3. capture and report the logs

The main thing that is missing here is throttling. Right now the controller will just create a new job right away.


Here is how to see the logs when the job fails:

```
$ kubectl -n influxdb get appinstances influxdb -o yaml | yq .status
lastLogs:
  fetch-app-instance: |
    rendered ok
  render-manifests: "trying next host\nerror reading data:,%28import%20%22oci:%2F%2Fus-docker.pkg.dev%2Finfluxdb2-artifacts%2Fclustered%2Finfluxdb:20230727-503750%22%29%20+%20%28%7BappInstance_+:import%20%22%2Foverlay%2Fappinstance.json%22%7D%29: RUNTIME ERROR: Get \"oci://us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:20230727-503750/\": failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://us-docker.pkg.dev/v2/token?scope=repository%3Ainfluxdb2-artifacts%2Fclustered%2Finfluxdb%3Apull&service=us-docker.pkg.dev: 401 Unauthorized\n\tfile:////:1:2-89\t$\n\tDuring evaluation\n"
```
