### PR TITLE
ci: add simple release step on tagged branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,9 @@ on:
 jobs:
   create_release:
     if: ${{ (github.event.workflow_run.conclusion == 'success') && startsWith(github.ref, 'refs/tags/v') }} # Skip if Rust workflow fails
-    name: Create Release
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-
     steps:
-      - name: Create Release
+      - name: create_release
         id: create_release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # renovate: tag=v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  workflow_run:
+    worfklows:
+      - "Rust"
+  types:
+    - completed
+  push:
+    tags:
+      - v*.*.*
+jobs:
+  create_release:
+    if: ${{ (github.event.workflow_run.conclusion == 'success') }} # Skip if Rust workflow fails
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # renovate: tag=v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+  release_image:
+    if: ${{ (github.event.workflow_run.conclusion == 'success') }} # Skip if Rust workflow fails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/kubecfg/kubit:${{ github.ref_name }}
+          cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,12 @@ on:
   workflow_run:
     worfklows:
       - "Rust"
-  types:
-    - completed
-  push:
-    tags:
-      - v*.*.*
+    types:
+      - completed
+
 jobs:
   create_release:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') }} # Skip if Rust workflow fails
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && startsWith(github.ref, 'refs/tags/v') }} # Skip if Rust workflow fails
     name: Create Release
     runs-on: ubuntu-latest
     outputs:
@@ -30,7 +28,7 @@ jobs:
           prerelease: false
 
   release_image:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') }} # Skip if Rust workflow fails
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && startsWith(github.ref, 'refs/tags/v' }} # Skip if Rust workflow fails
     runs-on: ubuntu-latest
     steps:
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,15 @@ jobs:
     if: ${{ (github.event.workflow_run.conclusion == 'success') && startsWith(github.ref, 'refs/tags/v') }} # Skip if Rust workflow fails
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2
+      - name: Login to GHCR
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: create_release
         id: create_release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # renovate: tag=v1
@@ -27,6 +36,15 @@ jobs:
     if: ${{ (github.event.workflow_run.conclusion == 'success') && startsWith(github.ref, 'refs/tags/v' }} # Skip if Rust workflow fails
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2
+      - name: Login to GHCR
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,3 +61,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
         if: github.event_name != 'pull_request'
+      - name: Release
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/kubecfg/kubit:${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,12 +61,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
         if: github.event_name != 'pull_request'
-      - name: Release
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/kubecfg/kubit:${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,9 +3,10 @@ name: Rust
 on:
   push:
     branches: ["main"]
+    tags:
+      - v*.*.*
   pull_request:
     branches: ["main"]
-
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Uses the [`github.ref_name`](https://docs.github.com/en/actions/learn-github-actions/contexts) as the tag to push a tagged image into GHCR, e.g. `v0.0.1`.

> The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub.
