### PR TITLE
ci: add github action validation step to main workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create_release:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && startsWith(github.ref, 'refs/tags/v') }} # Skip if Rust workflow fails
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (startsWith(github.ref, 'refs/tags/v')) }} # Skip if Rust workflow fails
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
@@ -33,7 +33,7 @@ jobs:
           prerelease: false
 
   release_image:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && startsWith(github.ref, 'refs/tags/v' }} # Skip if Rust workflow fails
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (startsWith(github.ref, 'refs/tags/v')) }} # Skip if Rust workflow fails
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+
+  check-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Install action-validator with asdf
+        uses: asdf-vm/actions/install@v2
+        with:
+          tool_versions: |
+            action-validator 0.5.3
+
+      - name: Lint Actions
+        run: |
+          find .github/workflows -type f \( -iname \*.yaml -o -iname \*.yml \) \
+            | xargs -I {} action-validator --verbose {}
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add an action to quickly validate whether our GitHub action changes are valid.

This also adds a fix to the current pipeline, as it was invalid but not picked up.

This `check-actions` snippet is directly from the projects own workflow https://github.com/mpalmer/action-validator/blob/e3b13841424960d973eb3aaf4d498781c09ef85c/.github/workflows/qa.yml#L184-L201
