### PR TITLE
chore: Use depot remote builds instead of buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2
+      - name: Set up Depot Docker Build
+        uses: depot/setup-action@v1
       - name: Login to GHCR
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
@@ -35,10 +35,17 @@ jobs:
   release_image:
     if: ${{ (github.event.workflow_run.conclusion == 'success') && (startsWith(github.ref, 'refs/tags/v')) }} # Skip if Rust workflow fails
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+      # Allows pushing to the GitHub Container Registry
+      packages: write
+
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2
+      - name: Set up Depot Docker Build
+        uses: depot/setup-action@v1
       - name: Login to GHCR
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
@@ -46,9 +53,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
+        uses: depot/build-push-action@v1
         with:
+          project: vz2l70b5lw
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/kubecfg/kubit:${{ github.ref_name }}
-          cache-from: type=gha

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,10 +33,16 @@ jobs:
   pack:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+      # Allows pushing to the GitHub Container Registry
+      packages: write
+
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2
+      - name: Set up Depot Docker Build
+        uses: depot/setup-action@v1
       - name: Login to GHCR
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
@@ -46,19 +52,19 @@ jobs:
         if: github.event_name != 'pull_request'
 
       - name: Build
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
+        uses: depot/build-push-action@v1
         with:
+          project: vz2l70b5lw
           context: .
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: ghcr.io/kubecfg/kubit:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
       - name: Push
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
+        uses: depot/build-push-action@v1
         with:
+          project: vz2l70b5lw
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/kubecfg/kubit:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
I tried a draft of this PR where we pushed to GHCR also during the PR build, so that I could try out depot GHCR auth.

(kudos to @kylegalbraith and @jacobwgillespie and everybody else on the depot team, you got a happy user today!)

Now I switched back to the original code that only pushed builds in `main` branch and releases.
I also updated the release pipeline, but that's hard to debug in a PR