### PR TITLE
ci: use depot for release image push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,16 +87,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: create_release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # renovate: tag=v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
-          draft: true
-          prerelease: false
       - name: release_image
         uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,13 @@ jobs:
       #   if: github.event_name != 'pull_request'
 
   release:
+
+    permissions:
+      contents: read
+      id-token: write
+      # Allows pushing to the GitHub Container Registry
+      packages: write
+
     needs: [pack, build]
     # if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,6 +90,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: create_release
+        id: create_release
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # renovate: tag=v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: true
+          prerelease: false
       - name: release_image
         uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,7 +98,7 @@ jobs:
           draft: true
           prerelease: false
       - name: release_image
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
+        uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
         with:
           project: vz2l70b5lw
           context: .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,20 +15,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - uses: Swatinem/rust-cache@578b235f6e5f613f7727f1c17bd3305b4d4d4e1f # v2
-      - name: Format
-        run: cargo fmt --all --check
-      - name: Lint
-        run: cargo clippy -- -D warnings
-      - name: Build
-        run: cargo build
-      - name: Generate
-        run: cargo run -- manifests --crd-dir kustomize/crd/bases
-      - name: Diff
-        run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
-      - name: Run tests
-        run: cargo test
+      - name: build
+        run: "Built!"
+      # - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      # - uses: Swatinem/rust-cache@578b235f6e5f613f7727f1c17bd3305b4d4d4e1f # v2
+      # - name: Format
+      #   run: cargo fmt --all --check
+      # - name: Lint
+      #   run: cargo clippy -- -D warnings
+      # - name: Build
+      #   run: cargo build
+      # - name: Generate
+      #   run: cargo run -- manifests --crd-dir kustomize/crd/bases
+      # - name: Diff
+      #   run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
+      # - name: Run tests
+      #   run: cargo test
 
   pack:
     runs-on: ubuntu-latest
@@ -40,38 +42,40 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: Set up Depot Docker Build
-        uses: depot/setup-action@b6821033ac2e40632f45def8e8a4f158c6f60980 # v1
-      - name: Login to GHCR
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name != 'pull_request'
+      - name:
+        run: "Packed!"
+      # - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      # - name: Set up Depot Docker Build
+      #   uses: depot/setup-action@b6821033ac2e40632f45def8e8a4f158c6f60980 # v1
+      # - name: Login to GHCR
+      #   uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+      #   if: github.event_name != 'pull_request'
 
-      - name: Build
-        uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
-        with:
-          project: vz2l70b5lw
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: ghcr.io/kubecfg/kubit:latest
-      - name: Push
-        uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
-        with:
-          project: vz2l70b5lw
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/kubecfg/kubit:latest
-        if: github.event_name != 'pull_request'
+      # - name: Build
+      #   uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
+      #   with:
+      #     project: vz2l70b5lw
+      #     context: .
+      #     platforms: linux/amd64,linux/arm64
+      #     push: false
+      #     tags: ghcr.io/kubecfg/kubit:latest
+      # - name: Push
+      #   uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
+      #   with:
+      #     project: vz2l70b5lw
+      #     context: .
+      #     platforms: linux/amd64,linux/arm64
+      #     push: true
+      #     tags: ghcr.io/kubecfg/kubit:latest
+      #   if: github.event_name != 'pull_request'
 
   release:
     needs: [pack, build]
-    if: startsWith(github.ref, 'refs/tags/v')
+    # if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,11 @@ name: Rust
 
 on:
   push:
-    branches: ["main"]
-    tags:
-      - v*.*.*
+    branches: ["ci/use-depot-for-release"]
+      # tags:
+      #   - v*.*.*
   pull_request:
-    branches: ["main"]
+    branches: ["ci/use-depot-for-release"]
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: build
-        run: "Built!"
+        run: "echo Built!"
       # - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       # - uses: Swatinem/rust-cache@578b235f6e5f613f7727f1c17bd3305b4d4d4e1f # v2
       # - name: Format
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name:
-        run: "Packed!"
+        run: "echo Packed!"
       # - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       # - name: Set up Depot Docker Build
       #   uses: depot/setup-action@b6821033ac2e40632f45def8e8a4f158c6f60980 # v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,11 @@ name: Rust
 
 on:
   push:
-    branches: ["ci/use-depot-for-release"]
-      # tags:
-      #   - v*.*.*
+    branches: ["main"]
+    tags:
+      - v*.*.*
   pull_request:
-    branches: ["ci/use-depot-for-release"]
+    branches: ["main"]
 env:
   CARGO_TERM_COLOR: always
 
@@ -15,22 +15,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: build
-        run: "echo Built!"
-      # - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      # - uses: Swatinem/rust-cache@578b235f6e5f613f7727f1c17bd3305b4d4d4e1f # v2
-      # - name: Format
-      #   run: cargo fmt --all --check
-      # - name: Lint
-      #   run: cargo clippy -- -D warnings
-      # - name: Build
-      #   run: cargo build
-      # - name: Generate
-      #   run: cargo run -- manifests --crd-dir kustomize/crd/bases
-      # - name: Diff
-      #   run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
-      # - name: Run tests
-      #   run: cargo test
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - uses: Swatinem/rust-cache@578b235f6e5f613f7727f1c17bd3305b4d4d4e1f # v2
+      - name: Format
+        run: cargo fmt --all --check
+      - name: Lint
+        run: cargo clippy -- -D warnings
+      - name: Build
+        run: cargo build
+      - name: Generate
+        run: cargo run -- manifests --crd-dir kustomize/crd/bases
+      - name: Diff
+        run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
+      - name: Run tests
+        run: cargo test
 
   pack:
     runs-on: ubuntu-latest
@@ -42,47 +40,45 @@ jobs:
       packages: write
 
     steps:
-      - name:
-        run: "echo Packed!"
-      # - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      # - name: Set up Depot Docker Build
-      #   uses: depot/setup-action@b6821033ac2e40632f45def8e8a4f158c6f60980 # v1
-      # - name: Login to GHCR
-      #   uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-      #   if: github.event_name != 'pull_request'
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Set up Depot Docker Build
+        uses: depot/setup-action@b6821033ac2e40632f45def8e8a4f158c6f60980 # v1
+      - name: Login to GHCR
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
 
-      # - name: Build
-      #   uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
-      #   with:
-      #     project: vz2l70b5lw
-      #     context: .
-      #     platforms: linux/amd64,linux/arm64
-      #     push: false
-      #     tags: ghcr.io/kubecfg/kubit:latest
-      # - name: Push
-      #   uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
-      #   with:
-      #     project: vz2l70b5lw
-      #     context: .
-      #     platforms: linux/amd64,linux/arm64
-      #     push: true
-      #     tags: ghcr.io/kubecfg/kubit:latest
-      #   if: github.event_name != 'pull_request'
+      - name: Build
+        uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
+        with:
+          project: vz2l70b5lw
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ghcr.io/kubecfg/kubit:latest
+      - name: Push
+        uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
+        with:
+          project: vz2l70b5lw
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/kubecfg/kubit:latest
+        if: github.event_name != 'pull_request'
 
   release:
 
+    # Allow depot permissions to GHCR
     permissions:
       contents: read
       id-token: write
-      # Allows pushing to the GitHub Container Registry
       packages: write
 
     needs: [pack, build]
-    # if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3


### PR DESCRIPTION
Our current CI fails with 

```
Error: buildx failed with: ERROR: Multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
```

However, we have since moved to `depot` for their speedy multi-arch images. So our regular `docker/build-push-action` needs changing to the `depot` specific one.

