### PR TITLE
Switch to kubecfg depot org

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
         with:
-          project: vz2l70b5lw
+          project: v8n5whjnsb
           context: .
           platforms: linux/amd64,linux/arm64
           push: false
@@ -62,7 +62,7 @@ jobs:
       - name: Push
         uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
         with:
-          project: vz2l70b5lw
+          project: v8n5whjnsb
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
@@ -103,7 +103,7 @@ jobs:
       - name: release_image
         uses: depot/build-push-action@39acb3f766a908058e746f5c7a166f73e4cdcb17 # v1
         with:
-          project: vz2l70b5lw
+          project: v8n5whjnsb
           context: .
           platforms: linux/amd64,linux/arm64
           push: true


### PR DESCRIPTION
I was using my personal depot account to evaluate depot remote docker build. I'm happy with it and I created an account for the kubecfg org