### PR TITLE
chore: Prepare for release v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "kubit"
-version = "0.1.0"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubit"
-version = "0.1.0"
+version = "0.0.5"
 license = "MIT"
 edition = "2021"
 keywords = ["kubernetes"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Usage
 
-- To install the operator, run `kubectl apply -k https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.4`
+- To install the operator, run `kubectl apply -k https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.5`
 - Install an `AppInstance` `CustomResource` that provides an OCI package and any necessary configuration
 - Watch as the operator pulls the package, and applies the configuration, deploying your services/etc
 

--- a/kustomize/manager/kustomization.yaml
+++ b/kustomize/manager/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
   - name: controller
     newName: ghcr.io/kubecfg/kubit
-    newTag: v0.0.4
+    newTag: v0.0.5


### PR DESCRIPTION
I realized there is another place where the version is stored: Cargo.toml (which is used by `kubit -V`)