### PR TITLE
fix: limit job duration time

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -458,6 +458,7 @@ async fn create_job(
                 spec: Some(PodSpec {
                     service_account: Some(APPLIER_SERVICE_ACCOUNT.to_string()),
                     restart_policy: Some("Never".to_string()),
+                    active_deadline_seconds: Some(60),
                     volumes: Some(volumes),
                     init_containers: Some(vec![
                         Container {


### PR DESCRIPTION
Sometimes pods on k8s get stuck for whatever reason; the controller should just retry