### PR TITLE
Implement kubit apply command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ pub mod controller;
 pub mod resources;
 
 pub mod apply;
+pub mod local;
 pub mod render;
+mod scripting;
 
 mod docker_config;

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use std::fs::{self, File};
+use std::io::{stdout, Write};
+use std::os::unix::prelude::PermissionsExt;
+use std::process::Command;
+
+use crate::{apply, render, resources::AppInstance, scripting::Script};
+
+#[derive(Clone, clap::ValueEnum)]
+pub enum DryRun {
+    Script,
+}
+
+/// Generate a script that runs kubecfg show and kubectl apply and runs it.
+pub fn apply(app_instance: &str, dry_run: &Option<DryRun>) -> Result<()> {
+    let (mut output, path): (Box<dyn Write>, _) = if matches!(dry_run, Some(DryRun::Script)) {
+        (Box::new(stdout()), None)
+    } else {
+        let tmp = tempfile::Builder::new().suffix(".sh").tempfile()?;
+        let path = tmp.path().to_path_buf();
+        (Box::new(tmp), Some(path))
+    };
+
+    let overlay_file_name = app_instance;
+    let file = File::open(overlay_file_name)?;
+    let app_instance: AppInstance = serde_yaml::from_reader(file)?;
+
+    let steps = vec![
+        Script::from_str("manifests=$(mktemp -d)"),
+        Script::from_str("export KUBECTL_APPLYSET=true"),
+        render::script(&app_instance, overlay_file_name, "${manifests}")?,
+        apply::script(&app_instance, "${manifests}")?,
+    ];
+    let script: Script = steps.into_iter().sum();
+
+    writeln!(output, "{script}")?;
+
+    if let Some(path) = path {
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755))?;
+        Command::new(path).status()?;
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 use clap::{Parser, Subcommand};
 use kube::CustomResourceExt;
 
-use kubit::{apply, controller, render, resources::AppInstance};
+use kubit::{apply, controller, local, render, resources::AppInstance};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -58,6 +58,16 @@ async fn main() -> anyhow::Result<()> {
             #[command(subcommand)]
             script: Scripts,
         },
+
+        /// Applies the template locally
+        Apply {
+            /// Path to the file containing a (YAML) AppInstance manifest.
+            app_instance: String,
+
+            /// Dry run
+            #[clap(long)]
+            dry_run: Option<local::DryRun>,
+        },
     }
 
     #[derive(Clone, Subcommand)]
@@ -95,6 +105,12 @@ async fn main() -> anyhow::Result<()> {
                 writeln!(out_writer, "---").unwrap();
                 serde_yaml::to_writer(out_writer, &crd).unwrap();
             }
+        }
+        Some(Commands::Apply {
+            app_instance,
+            dry_run,
+        }) => {
+            local::apply(app_instance, dry_run)?;
         }
         Some(Commands::Scripts {
             app_instance,

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,8 +1,8 @@
 use yash_quote::quoted;
 
-use crate::{resources::AppInstance, Error, Result};
+use crate::{resources::AppInstance, scripting::Script, Error, Result};
 
-/// Generates shell script that will render the manifest
+/// Generates shell script that will render the manifest and writes it to writer.
 pub fn emit_script<W>(app_instance: &AppInstance, w: &mut W) -> Result<()>
 where
     W: std::io::Write,
@@ -11,14 +11,19 @@ where
     let (mut file, path) = tmp.keep()?;
     serde_json::to_writer(&mut file, &app_instance).map_err(Error::RenderOverlay)?;
 
-    writeln!(w, "#!/bin/bash")?;
-    writeln!(w, "set -euo pipefail")?;
-
-    for i in emit_commandline(app_instance, &path.to_string_lossy(), "/tmp/manifests") {
-        write!(w, "{} ", quoted(&i))?;
-    }
-    writeln!(w)?;
+    let script = script(app_instance, &path.to_string_lossy(), "/tmp/manifests")?;
+    writeln!(w, "{script}")?;
     Ok(())
+}
+
+/// Generates shell script that will render the manifest
+pub fn script(
+    app_instance: &AppInstance,
+    overlay_file_name: &str,
+    output_dir: &str,
+) -> Result<Script> {
+    let tokens = emit_commandline(app_instance, overlay_file_name, output_dir);
+    Ok(Script::from_vec(tokens))
 }
 
 pub fn emit_commandline(

--- a/src/scripting.rs
+++ b/src/scripting.rs
@@ -1,0 +1,154 @@
+use std::{iter::Sum, ops};
+
+/// A shell script. I renders with a shebang header and sets the strict evaluation flags.
+/// Can be combined with other scripts.
+pub struct Script(String);
+
+impl Script {
+    pub fn from_str(str: &str) -> Self {
+        Self(str.to_string())
+    }
+
+    pub fn from_vec(tokens: Vec<String>) -> Self {
+        Self(
+            tokens
+                .iter()
+                .map(quoted)
+                .collect::<Vec<_>>()
+                .join(" \\\n    "),
+        )
+    }
+}
+
+// Quote all strings expect for explicit bash variable references
+fn quoted(src: &String) -> String {
+    if src.starts_with("${") {
+        format!(r#""{src}""#)
+    } else {
+        yash_quote::quoted(src).to_string()
+    }
+}
+
+impl std::fmt::Display for Script {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "#!/bin/bash")?;
+        writeln!(f, "set -euo pipefail")?;
+        writeln!(f)?;
+        write!(f, "{}", self.0)?;
+        Ok(())
+    }
+}
+
+impl ops::Add<Script> for Script {
+    type Output = Script;
+
+    fn add(self, rhs: Script) -> Self::Output {
+        Script(format!("{}\n{}", self.0, rhs.0))
+    }
+}
+
+impl Sum for Script {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        match iter.reduce(|lhs, rhs| lhs + rhs) {
+            Some(script) => script,
+            None => Self::from_vec(vec![]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_script() {
+        let script = Script::from_vec(
+            ["echo", "foo", "bar", "baz qux"]
+                .into_iter()
+                .map(|x| x.to_string())
+                .collect(),
+        );
+        let expected = r#"#!/bin/bash
+set -euo pipefail
+
+echo \
+    foo \
+    bar \
+    'baz qux'"#;
+        assert_eq!(format!("{script}"), expected);
+    }
+
+    #[test]
+    fn test_add() {
+        let script_a = Script::from_vec(
+            ["echo", "foo", "bar"]
+                .into_iter()
+                .map(|x| x.to_string())
+                .collect(),
+        );
+        let script_b = Script::from_vec(
+            ["echo", "baz qux"]
+                .into_iter()
+                .map(|x| x.to_string())
+                .collect(),
+        );
+        let combined = script_a + script_b;
+
+        let expected = r#"#!/bin/bash
+set -euo pipefail
+
+echo \
+    foo \
+    bar
+echo \
+    'baz qux'"#;
+        assert_eq!(format!("{combined}"), expected);
+    }
+
+    #[test]
+    fn test_sum() {
+        let scripts = vec![
+            Script::from_vec(
+                ["echo", "foo", "bar"]
+                    .into_iter()
+                    .map(|x| x.to_string())
+                    .collect(),
+            ),
+            Script::from_vec(
+                ["echo", "baz qux"]
+                    .into_iter()
+                    .map(|x| x.to_string())
+                    .collect(),
+            ),
+        ];
+
+        let combined: Script = scripts.into_iter().sum();
+
+        let expected = r#"#!/bin/bash
+set -euo pipefail
+
+echo \
+    foo \
+    bar
+echo \
+    'baz qux'"#;
+        assert_eq!(format!("{combined}"), expected);
+    }
+
+    #[test]
+    fn test_variable() {
+        let script = Script::from_vec(
+            ["echo", "quote_$_me", "${dont_quote_me}"]
+                .into_iter()
+                .map(|x| x.to_string())
+                .collect(),
+        );
+        let expected = r#"#!/bin/bash
+set -euo pipefail
+
+echo \
+    'quote_$_me' \
+    "${dont_quote_me}""#;
+        assert_eq!(format!("{script}"), expected);
+    }
+}


### PR DESCRIPTION
kubit is "just a thin" frontend around kubecfg that combine a template and an "app instance" yaml.

But nevertheless, even if in principle one can just invoke kubecfg with the appropriate flags to render and apply a template there are quite a bunch of flags.

it would be nice if we could just use kubit as helper  like that:

```console
kubit apply myappinstance.yaml
```

or even as a kubectl plugin!

```console
kubectl kubit apply myappinstance.yaml
```

--

This PR reuses the existing functions that generate kubecfg and kubectl invocations.

It creates a new module called `scripting` that helps with composing simple bash scripts. It handles argument quoting and adding common preamble like shebang etc.