### PR TITLE
chore: Use pipe instead of temp files

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -480,7 +480,7 @@ async fn create_job(
                             command: Some(render::emit_commandline(
                                 app_instance,
                                 "/overlay/appinstance.json",
-                                "/manifests",
+                                Some("/manifests"),
                             )),
                             ..container_defaults.clone()
                         },

--- a/src/local.rs
+++ b/src/local.rs
@@ -26,10 +26,9 @@ pub fn apply(app_instance: &str, dry_run: &Option<DryRun>) -> Result<()> {
     let app_instance: AppInstance = serde_yaml::from_reader(file)?;
 
     let steps = vec![
-        Script::from_str("manifests=$(mktemp -d)"),
         Script::from_str("export KUBECTL_APPLYSET=true"),
-        render::script(&app_instance, overlay_file_name, "${manifests}")?,
-        apply::script(&app_instance, "${manifests}")?,
+        render::script(&app_instance, overlay_file_name, None)?
+            | apply::script(&app_instance, "-")?,
     ];
     let script: Script = steps.into_iter().sum();
 

--- a/src/scripting.rs
+++ b/src/scripting.rs
@@ -47,6 +47,14 @@ impl ops::Add<Script> for Script {
     }
 }
 
+impl ops::BitOr<Script> for Script {
+    type Output = Script;
+
+    fn bitor(self, rhs: Script) -> Self::Output {
+        Script(format!("{} \\\n| {}", self.0, rhs.0))
+    }
+}
+
 impl Sum for Script {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         match iter.reduce(|lhs, rhs| lhs + rhs) {
@@ -149,6 +157,22 @@ set -euo pipefail
 echo \
     'quote_$_me' \
     "${dont_quote_me}""#;
+        assert_eq!(format!("{script}"), expected);
+    }
+
+    #[test]
+    fn test_pipe() {
+        let left = Script::from_vec(["echo", "foo"].into_iter().map(|x| x.to_string()).collect());
+        let right = Script::from_vec(["wc", "-c"].into_iter().map(|x| x.to_string()).collect());
+
+        let script = left | right;
+        let expected = r#"#!/bin/bash
+set -euo pipefail
+
+echo \
+    foo \
+| wc \
+    -c"#;
         assert_eq!(format!("{script}"), expected);
     }
 }


### PR DESCRIPTION
Before:

```bash
#!/bin/bash
set -euo pipefail

manifests=$(mktemp -d)
export KUBECTL_APPLYSET=true
kubecfg \
    show \
    --alpha \
    '--reorder=server' \
    oci://us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:20230814-529785 \
    --overlay-code-file \
    'appInstance_=/Users/mkm/tmp/appinstance.yaml' \
    --export-dir \
    "${manifests}" \
    --export-filename-format \
    '{{printf "%03d" (resourceIndex .)}}-{{.apiVersion}}.{{.kind}}-{{default "default" .metadata.namespace}}.{{.metadata.name}}'
kubectl \
    apply \
    -f \
    "${manifests}" \
    -n \
    influxdb \
    --server-side \
    --prune \
    --applyset \
    influxdb \
    --force-conflicts \
    '-v=2'
```

After:

```bash
#!/bin/bash
set -euo pipefail

export KUBECTL_APPLYSET=true
kubecfg \
    show \
    --alpha \
    '--reorder=server' \
    oci://us-docker.pkg.dev/influxdb2-artifacts/clustered/influxdb:20230814-529785 \
    --overlay-code-file \
    'appInstance_=/Users/mkm/tmp/appinstance.yaml' \
| kubectl \
    apply \
    -f \
    - \
    -n \
    influxdb \
    --server-side \
    --prune \
    --applyset \
    influxdb \
    --force-conflicts \
    '-v=2'
```

--

This will also make it easier to implement plain "render" step where we emit yaml manifests to stdout