### PR TITLE
Wrap apply under local subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can run the same logic that the kubit controller does when rendering and app
 the `kubit` CLI tool from your laptop:
 
 ```bash
-kubit apply foo.yaml
+kubit local apply foo.yaml
 ```
 
 Kubit is just a relatively thin wrapper on top of `kubecfg`.
@@ -95,7 +95,7 @@ tooling rather than kubecfg's integrated k8s API.
 You can preview the actuall commands that `kubit` will run with:
 
 ```bash
-kubit apply foo.yaml --dry-run=script
+kubit local apply foo.yaml --dry-run=script
 ```
 
 Other interesting options are `--dry-run=render` and `--dry-run=diff` which will respectively just render the YAML without applying it

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use clap::Subcommand;
 use kube::ResourceExt;
 use std::fs::{self, File};
 use std::io::{stdout, Write};
@@ -12,11 +13,36 @@ use crate::{
     scripting::Script,
 };
 
+#[derive(Clone, Subcommand)]
+pub enum Local {
+    /// Applies the template locally
+    Apply {
+        /// Path to the file containing a (YAML) AppInstance manifest.
+        app_instance: String,
+
+        /// Dry run
+        #[clap(long)]
+        dry_run: Option<DryRun>,
+    },
+}
+
 #[derive(Clone, clap::ValueEnum)]
 pub enum DryRun {
     Render,
     Diff,
     Script,
+}
+
+pub fn run(local: &Local) -> Result<()> {
+    match local {
+        Local::Apply {
+            app_instance,
+            dry_run,
+        } => {
+            apply(app_instance, dry_run)?;
+        }
+    };
+    Ok(())
 }
 
 /// Generate a script that runs kubecfg show and kubectl apply and runs it.

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,14 +59,10 @@ async fn main() -> anyhow::Result<()> {
             script: Scripts,
         },
 
-        /// Applies the template locally
-        Apply {
-            /// Path to the file containing a (YAML) AppInstance manifest.
-            app_instance: String,
-
-            /// Dry run
-            #[clap(long)]
-            dry_run: Option<local::DryRun>,
+        /// Run operator logic locally from the CLI
+        Local {
+            #[command(subcommand)]
+            local: local::Local,
         },
     }
 
@@ -106,12 +102,7 @@ async fn main() -> anyhow::Result<()> {
                 serde_yaml::to_writer(out_writer, &crd).unwrap();
             }
         }
-        Some(Commands::Apply {
-            app_instance,
-            dry_run,
-        }) => {
-            local::apply(app_instance, dry_run)?;
-        }
+        Some(Commands::Local { local }) => local::run(local)?,
         Some(Commands::Scripts {
             app_instance,
             script,


### PR DESCRIPTION
The `kubit apply -f foo.yaml`  command is too similar to `kubectl apply -f foo.yaml` and it may be surprising that it doesn't actually apply the foo.yaml CR itself but instead it runs the operator logic locally.

Wrapping that command (and possibly others) under a `local` command group is likely going to be much more intuitive to users.