### PR TITLE
feat: Allow to quickly override package image from CLI

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -37,12 +37,18 @@ pub fn emit_commandline(
 ) -> Vec<String> {
     let image = &app_instance.spec.package.image;
 
+    let entrypoint = if image.starts_with("file://") {
+        image.clone()
+    } else {
+        format!("oci://{image}")
+    };
+
     let mut cli = [
         "kubecfg",
         "show",
         "--alpha",
         "--reorder=server",
-        &format!("oci://{image}"),
+        &entrypoint,
         "--overlay-code-file",
         &format!("appInstance_={overlay_file}"),
     ]


### PR DESCRIPTION
Demo:

```bash
kubit local apply ~/tmp/appinstance.yaml --dry-run=diff --package-image=file://$HOME/myproject/main.jsonnet
```

This is the equivalent of:

```
kubecfg show ~/myproject/main.jsonnet --overlay-code-file appInstance=~/tmp/appinstance.yaml | kubectl diff -f -
```

but it works more naturally if you're already in the flow of using `kubit local` and thinking of your app instance yaml file as your main entry point and _occasionally_ you want to quickly try out what it would be like using the jsonnet source files before pushing them to the OCI registry

---

This PR makes two changes:

1. allows file:// urls in the `.spec.package.image` field.
2. adds a `--package-image` CLI flag to the `apply` command.

You don't have to use the --package-image flag, you can also edit your YAML file and point it to your source jsonnet files directly if you prefer.