### PR TITLE
Implement pause

### DIFF
--- a/kustomize/crd/bases/kubecfg.dev_appinstances.yaml
+++ b/kustomize/crd/bases/kubecfg.dev_appinstances.yaml
@@ -44,6 +44,9 @@ spec:
                 - image
                 - spec
                 type: object
+              pause:
+                description: If true, the controller will not reconcile this application. You can use this if you need to do some manual changes (either with kubectl directly or with kubit CLI)
+                type: boolean
             required:
             - package
             type: object

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -135,6 +135,15 @@ async fn reconcile(app_instance: Arc<AppInstance>, ctx: Arc<Context>) -> Result<
     // slow down things a little bit
     tokio::time::sleep(Duration::from_secs(1)).await;
 
+    if app_instance.spec.pause {
+        info!(
+            name = app_instance.name_any(),
+            ns = app_instance.namespace(),
+            "paused"
+        );
+        return Ok(Action::await_change());
+    }
+
     let state = reconciliation_state(&app_instance, &ctx).await?;
     info!(?state);
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -19,6 +19,12 @@ use serde::{Deserialize, Serialize};
 pub struct AppInstanceSpec {
     pub package: Package,
     pub image_pull_secrets: Option<Vec<LocalObjectReference>>,
+
+    /// If true, the controller will not reconcile this application.
+    /// You can use this if you need to do some manual changes (either with kubectl directly or with kubit CLI)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub pause: bool,
 }
 
 // Like k8s_openapi::api::core::v1::LocalObjectReference but derives JsonSchema


### PR DESCRIPTION
This PR adds a `.spec.pause` boolean flag that will cause a running controller to ignore an AppInstance until the flag is true.

```
    /// If true, the controller will not reconcile this application.
    /// You can use this if you need to do some manual changes (either with kubectl directly or with kubit CLI)
```

This is modeled on a similarly named fluxcd field