### PR TITLE
fix: fix rbac so it can prune resources 

### DIFF
--- a/kustomize/rbac/role.yaml
+++ b/kustomize/rbac/role.yaml
@@ -73,4 +73,4 @@ rules:
   # we need to have the same permissions the jobs has otherwise we cannot create the RBAC
   - apiGroups: ["*"]
     resources: ["*"]
-    verbs: ["create", "update", "get", "list", "patch", "watch"]
+    verbs: ["create", "update", "get", "list", "patch", "watch", "delete"]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -402,10 +402,12 @@ async fn setup_job_rbac(app_instance: &AppInstance, ctx: &Context) -> Result<()>
         rules: Some(vec![PolicyRule {
             api_groups: Some(["*"].iter().map(|s| s.to_string()).collect()),
             resources: Some(["*"].iter().map(|s| s.to_string()).collect()),
-            verbs: ["create", "update", "get", "list", "patch", "watch"]
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
+            verbs: [
+                "create", "update", "get", "list", "patch", "watch", "delete",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
             ..Default::default()
         }]),
     };


### PR DESCRIPTION
`kubectl apply --prune` can delete resources that are no longer referenced in the input manifests.
However we forgot to add the `delete` verb to the `kubit-applier` role.

Before:

```
 error: pruning Job.batch influxdb/token-gen-ac6502b4: jobs.batch "token-gen-ac6502b4" is forbidden: User "system:serviceaccount:influxdb:kubit-applier" cannot delete resource "jobs" in API group "batch" in the namespace "influxdb"
```

After:
```
...
  job.batch/token-gen-ac6502b4 pruned
```