### PR TITLE
feat: Add --as to local apply

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -8,19 +8,27 @@ pub fn emit_script<W>(app_instance: &AppInstance, w: &mut W) -> Result<()>
 where
     W: std::io::Write,
 {
-    let script = script(app_instance, "/tmp/manifests")?;
+    let script = script(app_instance, "/tmp/manifests", &None)?;
     write!(w, "{script}")?;
     Ok(())
 }
 
 /// Generates shell script that will apply the manifests
-pub fn script(app_instance: &AppInstance, manifests_dir: &str) -> Result<Script> {
-    let tokens = emit_commandline(app_instance, manifests_dir);
+pub fn script(
+    app_instance: &AppInstance,
+    manifests_dir: &str,
+    as_user: &Option<String>,
+) -> Result<Script> {
+    let tokens = emit_commandline(app_instance, manifests_dir, as_user);
     Ok(Script::from_vec(tokens))
 }
 
-pub fn emit_commandline(app_instance: &AppInstance, manifests_dir: &str) -> Vec<String> {
-    vec![
+pub fn emit_commandline(
+    app_instance: &AppInstance,
+    manifests_dir: &str,
+    as_user: &Option<String>,
+) -> Vec<String> {
+    let mut cli = vec![
         "kubectl",
         "apply",
         "-f",
@@ -38,5 +46,11 @@ pub fn emit_commandline(app_instance: &AppInstance, manifests_dir: &str) -> Vec<
     ]
     .iter()
     .map(|s| s.to_string())
-    .collect()
+    .collect::<Vec<_>>();
+
+    if let Some(as_user) = as_user {
+        cli.push(format!("--as={as_user}"));
+    }
+
+    cli
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -515,7 +515,7 @@ async fn create_job(
                     containers: vec![Container {
                         name: "apply-manifests".to_string(),
                         image: Some(KUBECTL_IMAGE.to_string()),
-                        command: Some(apply::emit_commandline(app_instance, "/manifests")),
+                        command: Some(apply::emit_commandline(app_instance, "/manifests", &None)),
                         ..container_defaults.clone()
                     }],
                     ..Default::default()


### PR DESCRIPTION
If you want to simulate how would the in-cluster kubit controller apply a package that you have not yet pushed you can now run:

```bash
kubit local apply appinstance.yaml --package-image file://$PWD/main.jsonnet --as system:serviceaccount:influxdb:kubit-applier
```