### PR TITLE
feat: Add command to fetch appinstance

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,44 @@
+use std::fs::File;
+
+use anyhow::Result;
+use clap::Subcommand;
+use kube::{Api, Client};
+
+use crate::resources::AppInstance;
+
+/// Commands used by the kubit controller
+#[derive(Clone, Subcommand)]
+#[clap(hide = true)]
+pub enum Helper {
+    /// Fetch an AppInstance resource and output to a file.
+    ///
+    /// It removes the status field.
+    FetchAppInstance {
+        #[arg(long)]
+        namespace: String,
+
+        #[arg(long, help = "output file")]
+        output: String,
+
+        app_instance: String,
+    },
+}
+
+pub async fn run(helper: &Helper) -> Result<()> {
+    match helper {
+        Helper::FetchAppInstance {
+            namespace,
+            app_instance,
+            output,
+        } => {
+            let client = Client::try_default().await?;
+            let api: Api<AppInstance> = Api::namespaced(client, namespace);
+            let mut app_instance = api.get(app_instance).await?;
+            app_instance.status = None;
+
+            let file = File::create(output)?;
+            serde_json::to_writer_pretty(file, &app_instance)?;
+        }
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod controller;
 pub mod resources;
 
 pub mod apply;
+pub mod helpers;
 pub mod local;
 pub mod metadata;
 pub mod render;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 use clap::{Parser, Subcommand};
 use kube::CustomResourceExt;
 
-use kubit::{apply, controller, local, metadata, render, resources::AppInstance};
+use kubit::{apply, controller, helpers, local, metadata, render, resources::AppInstance};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -69,9 +69,15 @@ async fn main() -> anyhow::Result<()> {
             local: local::Local,
         },
 
+        /// Retreive metadata from an AppInstance's package
         Metadata {
             #[command(subcommand)]
             metadata: metadata::Metadata,
+        },
+
+        Helper {
+            #[command(subcommand)]
+            helper: helpers::Helper,
         },
     }
 
@@ -114,6 +120,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Metadata { metadata }) => metadata::run(metadata).await?,
         Some(Commands::Local { local }) => local::run(local, &client.impersonate_user)?,
+        Some(Commands::Helper { helper }) => helpers::run(helper).await?,
         Some(Commands::Scripts {
             app_instance,
             script,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,7 +11,11 @@ use crate::{
 
 #[derive(Clone, Subcommand)]
 pub enum Metadata {
+    /// Retrieve the JSON schema for the package `spec`.
     Schema { app_instance: String },
+
+    /// Retrieve the list of OCI images referenced by the package.
+    /// It can be useful when using private mirror for air-gapped environments.
     Images { app_instance: String },
 }
 


### PR DESCRIPTION
Currently the kubit controller needs to run `kubectl get -o json >outputfile` to fetch the appinstance. This requires a shell.
The official kubectl image from the k8s repo doesn't come with a shell, so we have to use the bitnami image. I like the bitnami image but I'd prefer to be able to use any kubectl image, especially the official one.

Furthermore, the kubectl get approach also fetches the status. I think the template engine shouldn't have access to the status field that contains it's own previous output (in the logs).

This PR just adds the `kubit helpers fetch-app-instance` command (which is hidden from casual CLI users) and doesn't change the controller to actually using it.