### PR TITLE
ci: add `create_release` step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,6 +69,23 @@ jobs:
           tags: ghcr.io/kubecfg/kubit:latest
         if: github.event_name != 'pull_request'
 
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [build, pack]
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # renovate: tag=v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: true
+          prerelease: false
+
   release:
 
     # Allow depot permissions to GHCR


### PR DESCRIPTION
This was taken directly from the [`kubecfg`](https://github.com/kubecfg/kubecfg/blob/4c033328ff911209913d7694a08fcd1ee85ecadd/.github/workflows/go.yml#L87-L105) release pipeline, with a few line removals where we do not use them in this repository.


We currently only publish an image into `ghcr.io`, it'll be nice to have proper GitHub releases where we can place changelogs or any other necessary information about a release of the project.