### PR TITLE
fix: remove duplicate `KUBIT` naming in env vars

### DIFF
--- a/kustomize/manager/manager.yaml
+++ b/kustomize/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         - image: controller:latest
           name: manager
           env:
-            - name: KUBIT_IMAGE
+            - name: KUBIT_CONTROLLER_IMAGE
               value: controller:latest
           securityContext:
             allowPrivilegeEscalation: false

--- a/kustomize/manager/manager.yaml
+++ b/kustomize/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         - image: controller:latest
           name: manager
           env:
-            - name: KUBIT_KUBIT_IMAGE
+            - name: KUBIT_IMAGE
               value: controller:latest
           securityContext:
             allowPrivilegeEscalation: false

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
 
         #[clap(
             long,
-            env = "KUBIT_IMAGE",
+            env = "KUBIT_CONTROLLER_IMAGE",
            default_value = concat!("ghcr.io/kubecfg/kubit:v", env!("CARGO_PKG_VERSION"))
         )]
         kubit_image: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
 
         #[clap(
             long,
-            env = "KUBIT_KUBIT_IMAGE",
+            env = "KUBIT_IMAGE",
            default_value = concat!("ghcr.io/kubecfg/kubit:v", env!("CARGO_PKG_VERSION"))
         )]
         kubit_image: String,


### PR DESCRIPTION
Whilst I can understand that this is along the lines of "Kubit's kubit image", as opposed to the `kubecfg` specific one, I think the double `KUBIT` in the environment variable doesn't make too much sense ~~and the intention of `KUBIT_IMAGE` is already clear.~~

Perhaps `KUBIT_CONTROLLER_IMAGE` instead? If we want to be extra clear. (**edit:** I've swapped to this now)
