### PR TITLE
fix: bump `active_deadline_seconds` to 180

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -491,7 +491,7 @@ async fn create_job(
                 spec: Some(PodSpec {
                     service_account: Some(APPLIER_SERVICE_ACCOUNT.to_string()),
                     restart_policy: Some("Never".to_string()),
-                    active_deadline_seconds: Some(60),
+                    active_deadline_seconds: Some(180),
                     volumes: Some(volumes),
                     init_containers: Some(vec![
                         Container {


### PR DESCRIPTION
This is something which I've noticed when running locally, such that the `activeDeadlineSeconds` countdown begins as soon as the `Pod` starts running, meaning that the task can be half-completed and then terminated with `DeadlineExceeded`.

Whilst this isn't a huge problem because the tasks can be retried, it also might be confusing to see the `Pod` itself fail and then be restarted, only to succeed on the 2nd or 3rd attempt. I believe we can easily get around this by bumping the time to complete the `Pod`'s work itself:

**Note:** This is being set on the `Pod.spec` too, rather than the `Job.spec`:

```
kubectl explain pod.spec.activeDeadlineSeconds
...
duration in seconds the pod may be active on the node relative to
StartTime before the system will actively try to mark it failed and kill
associated containers.
```

If we think that `180` is too high, then I believe a good compromise is `120`, doubling the current value.
