### PR TITLE
feat: include fake package demo from `kubecfg pack` for tests

### DIFF
--- a/.github/workflows/package_demo.yml
+++ b/.github/workflows/package_demo.yml
@@ -1,12 +1,10 @@
 name: pack/push package demo
 on:
   push:
-    branches: ["main"]
-  pull_request:
-    branches: ["feat/demo-package-for-tests"]
-  schedule:
-    # Every 6 hours
-    - cron: '0 */6 * * *'
+    #  branches: ["main"]
+      #schedule:
+      #  # Every 6 hours
+      #  - cron: '0 */6 * * *'
 
 
 jobs:

--- a/.github/workflows/package_demo.yml
+++ b/.github/workflows/package_demo.yml
@@ -2,6 +2,8 @@ name: pack/push package demo
 on:
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["feat/demo-package-for-tests"]
   schedule:
     # Every 6 hours
     - cron: '0 */6 * * *'

--- a/.github/workflows/package_demo.yml
+++ b/.github/workflows/package_demo.yml
@@ -1,0 +1,33 @@
+name: pack/push package demo
+on:
+  push:
+    branches: ["main"]
+  schedule:
+    # Every 6 hours
+    - cron: '0 */6 * * *'
+
+
+jobs:
+  check-actions:
+    runs-on: ubuntu-latest
+  push_package_demo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+      - name: Login to GHCR
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        # if: github.event_name != 'pull_request'
+      - name: Install kubecfgpack
+        run: go install github.com/kubecfg/kubecfg@latest
+      - name: Version and Pack
+        run: |
+          kubecfg version
+          kubecfg pack --alpha ghcr.io/kubecfg/kubit/package-demo:v1 tests/fixtures/shell.jsonnet

--- a/.github/workflows/package_demo.yml
+++ b/.github/workflows/package_demo.yml
@@ -1,18 +1,15 @@
 name: pack/push package demo
 on:
   push:
-    #  branches: ["main"]
-      #schedule:
-      #  # Every 6 hours
-      #  - cron: '0 */6 * * *'
+    branches: ["main"]
+  schedule:
+    # Every 6 hours
+    - cron: '0 */6 * * *'
 
 
 jobs:
-  check-actions:
-    runs-on: ubuntu-latest
   push_package_demo:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4

--- a/.github/workflows/package_demo.yml
+++ b/.github/workflows/package_demo.yml
@@ -24,10 +24,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        # if: github.event_name != 'pull_request'
-      - name: Install kubecfgpack
+      - name: Install kubecfg
         run: go install github.com/kubecfg/kubecfg@latest
-      - name: Version and Pack
-        run: |
-          kubecfg version
-          kubecfg pack --alpha ghcr.io/kubecfg/kubit/package-demo:v1 tests/fixtures/shell.jsonnet
+      - name: Check version
+        run: kubecfg version
+      - name: Run kubecfg pack
+        run: kubecfg pack --alpha ghcr.io/kubecfg/kubit/package-demo:v1 tests/fixtures/shell.jsonnet

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,9 +33,6 @@ jobs:
   push_package_demo:
     runs-on: ubuntu-latest
 
-  pack:
-    runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-go@v93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
@@ -51,6 +48,15 @@ jobs:
       - run: |
           go install github.com/kubecfg/kubecfg@latest
           kubecfg pack --alpha ghcr.io/kubecfg/kubit/package-demo:v1 tests/fixtures/shell.jsonnet
+
+  pack:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+      # Allows pushing to the GitHub Container Registry
+      packages: write
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,8 +45,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
         # if: github.event_name != 'pull_request'
-      - run: |
-          go install github.com/kubecfg/kubecfg@latest
+      - name: Install kubecfgpack
+        run: go install github.com/kubecfg/kubecfg@latest
+      - name: Version and Pack
+        run: |
+          kubecfg version
           kubecfg pack --alpha ghcr.io/kubecfg/kubit/package-demo:v1 tests/fixtures/shell.jsonnet
 
   pack:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,14 +30,27 @@ jobs:
       - name: Run tests
         run: cargo test
 
+  push_package_demo:
+    runs-on: ubuntu-latest
+
   pack:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      id-token: write
-      # Allows pushing to the GitHub Container Registry
-      packages: write
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-go@v93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+      - name: Login to GHCR
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        # if: github.event_name != 'pull_request'
+      - run: |
+          go install github.com/kubecfg/kubecfg@latest
+          kubecfg pack --alpha ghcr.io/kubecfg/kubit/package-demo:v1 tests/fixtures/shell.jsonnet
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,28 +30,6 @@ jobs:
       - name: Run tests
         run: cargo test
 
-  push_package_demo:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
-      - name: Login to GHCR
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        # if: github.event_name != 'pull_request'
-      - name: Install kubecfgpack
-        run: go install github.com/kubecfg/kubecfg@latest
-      - name: Version and Pack
-        run: |
-          kubecfg version
-          kubecfg pack --alpha ghcr.io/kubecfg/kubit/package-demo:v1 tests/fixtures/shell.jsonnet
-
   pack:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: actions/setup-go@v93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
       - name: Login to GHCR

--- a/src/render.rs
+++ b/src/render.rs
@@ -204,7 +204,7 @@ mod tests {
         let expected = vec![
             "kubecfg",
             "show",
-            "oci://gcr.io/mkm-cloud/package-demo:v1",
+            "oci://ghcr.io/kubecfg/kubit/package-demo:v1",
             "--alpha",
             "--reorder=server",
             "--overlay-code-file",

--- a/tests/fixtures/fake-package.yml
+++ b/tests/fixtures/fake-package.yml
@@ -5,8 +5,8 @@ metadata:
   namespace: test
 spec:
   package:
-    image: gcr.io/mkm-cloud/package-demo:v1
-    apiVersion: mkmik.pub/v1alpha1
+    image: ghcr.io/kubecfg/kubit/package-demo:v1
+    apiVersion: kubit.dev/v1alpha1
     spec:
       foo: 'bar'
       baz: 'qux'

--- a/tests/fixtures/shell.jsonnet
+++ b/tests/fixtures/shell.jsonnet
@@ -1,0 +1,57 @@
+// Example jsonnet used for a package.
+{
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: 'shell',
+    },
+    spec: {
+      clusterIP: 'None',
+      selector: {
+        app: 'shell',
+      },
+    },
+  },
+  sts: {
+    apiVersion: 'apps/v1',
+    kind: 'StatefulSet',
+    metadata: {
+      name: 'shell',
+    },
+    spec: {
+      minReadySeconds: 30,
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'shell',
+        },
+      },
+      serviceName: 'shell',
+      template: {
+        metadata: {
+          labels: {
+            app: 'shell',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              command: [
+                'bash',
+                '-c',
+                'set -e\nsleep 2\napt-get update\napt-get install -y curl wget\nsleep 1000002\n',
+              ],
+              image: 'debian:11',
+              name: 'shell',
+              securityContext: {
+                privileged: false,
+              },
+            },
+          ],
+          terminationGracePeriodSeconds: 2,
+        },
+      },
+    },
+  },
+}

--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::str::from_utf8;
 
-const DEMO_PACKAGE: &str = "oci://gcr.io/mkm-cloud/package-demo:v1";
+const DEMO_PACKAGE: &str = "oci://ghcr.io/kubecfg/kubit/package-demo:v1";
 const TEST_FILE: &str = "tests/fixtures/fake-package.yml";
 
 #[tokio::test]


### PR DESCRIPTION
The current fixture from `gcr.io/mkm-cloud` was created from a laptop and pushing into a public registry, we can use the same `jsonnet` file and bring it under `kubit` so that we control it.

An issue we have at the moment is that the package metadata on the image is out of date, it was built with an older version of `kubecfg` which is causing a test to fail that I'm writing in another branch, this is a necessary yak to shave in order to have a consistent package that we can assert against.

This PR gives us the same thing, but from within `kubit` and pushed into the `ghcr.io` registry instead for keeping everything contained to this project.