### PR TITLE
feat: add `--dry-run render` test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Run all tests
         run: cargo test
 
-
   pack:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,21 +27,21 @@ jobs:
         run: cargo run -- manifests --crd-dir kustomize/crd/bases
       - name: Diff
         run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
-      - name: Run tests
+      - name: Run unit tests
         run: cargo test --lib
 
   integration_tests:
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
-      - uses: AbsaOSS/k3d-action@v2
-        name: integration test cluster
+      - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: "kubit-test-cluster-1"
-      - name: Run tests
+      - name: Run all tests
         run: cargo test
 
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,10 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+      - uses: AbsaOSS/k3d-action@v2
+        name: integration test cluster
+        with:
+          cluster-name: "kubit-test-cluster-1"
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2
       - name: Format
         run: cargo fmt --all --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Diff
         run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
       - name: Run tests
-        run: cargo test
+        run: cargo test -- --nocapture
 
   pack:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,12 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
-      - uses: AbsaOSS/k3d-action@v2
-        name: integration test cluster
-        with:
-          cluster-name: "kubit-test-cluster-1"
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2
       - name: Format
         run: cargo fmt --all --check
@@ -34,7 +28,22 @@ jobs:
       - name: Diff
         run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
       - name: Run tests
-        run: cargo test -- --nocapture
+        run: cargo test --lib
+
+  integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+      - uses: AbsaOSS/k3d-action@v2
+        name: integration test cluster
+        with:
+          cluster-name: "kubit-test-cluster-1"
+      - name: Run tests
+        run: cargo test
+
 
   pack:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2
       - name: Format
         run: cargo fmt --all --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: "kubit-test-cluster-1"

--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -58,12 +58,12 @@ async fn local_apply_dry_run_render() {
             "render",
             "--skip-auth",
         ])
-        .unwrap()
-        .stdout
-        .to_vec();
-
-    let output = from_utf8(&output).expect("unable to read output script");
+        .unwrap();
     println!("{output:?}");
+
+    let vec_out = &output.stdout.to_vec();
+
+    let output = from_utf8(vec_out).expect("unable to read output script");
 
     // Assert some known required items in the rendered output.
     assert!(output.contains("gar-docker-secret"));

--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -58,15 +58,14 @@ async fn local_apply_dry_run_render() {
             "render",
             "--skip-auth",
         ])
-        .unwrap();
-    println!("{output:?}");
+        .unwrap()
+        .stdout
+        .to_vec();
 
-    let vec_out = &output.stdout.to_vec();
-
-    let output = from_utf8(vec_out).expect("unable to read output script");
+    let output = from_utf8(&output).expect("unable to read output script");
 
     // Assert some known required items in the rendered output.
-    assert!(output.contains("gar-docker-secret"));
+    assert!(output.contains("apiVersion"));
     assert!(output.contains("StatefulSet"));
     assert!(output.contains("Service"));
     assert!(output.contains("AppInstance"));

--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -63,6 +63,7 @@ async fn local_apply_dry_run_render() {
         .to_vec();
 
     let output = from_utf8(&output).expect("unable to read output script");
+    println!("{output:?}");
 
     // Assert some known required items in the rendered output.
     assert!(output.contains("gar-docker-secret"));

--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -57,31 +57,19 @@ async fn local_apply_dry_run_render() {
             "--dry-run",
             "render",
             "--skip-auth",
-        ]);
-    println!("{output:?}");
+        ])
+        .unwrap()
+        .stdout
+        .to_vec();
 
-    let output = output.unwrap();
-    println!("{output:?}");
+    let output = from_utf8(&output).expect("unable to read output script");
 
-    let vectorised_output = &output.stdout.to_vec();
-    let output = from_utf8(vectorised_output).expect("unable to read output script");
-    let overlay_file = PathBuf::from(
-        std::fs::canonicalize(TEST_FILE)
-            .expect("unable to find realpath for test")
-            .file_name()
-            .unwrap(),
-    );
-
-    println!("{:?}", output);
-
-
-    // Assert some known required items in the output command.
-    //assert!(output.contains("docker"));
-    //assert!(output.contains(DEMO_PACKAGE));
-    //assert!(output.contains(KUBECTL_IMAGE));
-    //assert!(output.contains(KUBECFG_IMAGE));
-    //assert!(output.contains(KUBECTL_APPLYSET_ENABLED));
-    //assert!(output.contains(KUBIT_APPLIER_FIELD_MANAGER));
-    //assert!(output.contains("--server-side"));
-    //assert!(output.contains(&format!("appInstance_=/overlay/{}", overlay_file.display())));
+    // Assert some known required items in the rendered output.
+    assert!(output.contains("apiVersion"));
+    assert!(output.contains("kind"));
+    assert!(output.contains("StatefulSet"));
+    assert!(output.contains("Service"));
+    assert!(output.contains("AppInstance"));
+    assert!(output.contains("kubecfg.dev/v1alpha1"));
+    assert!(output.contains(DEMO_PACKAGE.strip_prefix("oci://").unwrap()));
 }

--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -20,10 +20,11 @@ async fn local_apply_dry_run_script() {
             "script",
             "--skip-auth",
         ])
-        .unwrap();
+        .unwrap()
+        .stdout
+        .to_vec();
 
-    let vectorised_output = &output.stdout.to_vec();
-    let output = from_utf8(vectorised_output).expect("unable to read output script");
+    let output = from_utf8(&output).expect("unable to read output script");
     let overlay_file = PathBuf::from(
         std::fs::canonicalize(TEST_FILE)
             .expect("unable to find realpath for test")
@@ -44,7 +45,6 @@ async fn local_apply_dry_run_script() {
     // When using --skip-auth we should not mount credentials
     assert!(!output.contains("DOCKER_CONFIG"));
 }
-
 
 #[tokio::test]
 async fn local_apply_dry_run_render() {

--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -40,4 +40,48 @@ async fn local_apply_dry_run_script() {
     assert!(output.contains(KUBIT_APPLIER_FIELD_MANAGER));
     assert!(output.contains("--server-side"));
     assert!(output.contains(&format!("appInstance_=/overlay/{}", overlay_file.display())));
+
+    // When using --skip-auth we should not mount credentials
+    assert!(!output.contains("DOCKER_CONFIG"));
+}
+
+
+#[tokio::test]
+async fn local_apply_dry_run_render() {
+    let mut cmd = Command::cargo_bin("kubit").unwrap();
+    let output = cmd
+        .args([
+            "local",
+            "apply",
+            TEST_FILE,
+            "--dry-run",
+            "render",
+            "--skip-auth",
+        ]);
+    println!("{output:?}");
+
+    let output = output.unwrap();
+    println!("{output:?}");
+
+    let vectorised_output = &output.stdout.to_vec();
+    let output = from_utf8(vectorised_output).expect("unable to read output script");
+    let overlay_file = PathBuf::from(
+        std::fs::canonicalize(TEST_FILE)
+            .expect("unable to find realpath for test")
+            .file_name()
+            .unwrap(),
+    );
+
+    println!("{:?}", output);
+
+
+    // Assert some known required items in the output command.
+    //assert!(output.contains("docker"));
+    //assert!(output.contains(DEMO_PACKAGE));
+    //assert!(output.contains(KUBECTL_IMAGE));
+    //assert!(output.contains(KUBECFG_IMAGE));
+    //assert!(output.contains(KUBECTL_APPLYSET_ENABLED));
+    //assert!(output.contains(KUBIT_APPLIER_FIELD_MANAGER));
+    //assert!(output.contains("--server-side"));
+    //assert!(output.contains(&format!("appInstance_=/overlay/{}", overlay_file.display())));
 }

--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -65,8 +65,7 @@ async fn local_apply_dry_run_render() {
     let output = from_utf8(&output).expect("unable to read output script");
 
     // Assert some known required items in the rendered output.
-    assert!(output.contains("apiVersion"));
-    assert!(output.contains("kind"));
+    assert!(output.contains("gar-docker-secret"));
     assert!(output.contains("StatefulSet"));
     assert!(output.contains("Service"));
     assert!(output.contains("AppInstance"));


### PR DESCRIPTION
This builds from both https://github.com/kubecfg/kubit/pull/185 and https://github.com/kubecfg/kubit/pull/210. It adds another integration test, but this time for the `--dry-run render` output, ensuring that the rendered output contains some known items that we expect to see, such as the `AppInstance` resource.

I was considering running a `serde_yaml` serialisation here and testing equality but I think the simple `.contains()` does what we want with minimal complexity, although I'm happy to alter this if needs be.
