### PR TITLE
chore: Use k8s api LocalObjectReference

### DIFF
--- a/kustomize/crd/bases/kubecfg.dev_appinstances.yaml
+++ b/kustomize/crd/bases/kubecfg.dev_appinstances.yaml
@@ -23,9 +23,10 @@ spec:
             properties:
               imagePullSecrets:
                 items:
+                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      nullable: true
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                   type: object
                 nullable: true

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+use k8s_openapi::{api::core::v1::LocalObjectReference, apimachinery::pkg::apis::meta::v1::Time};
 use kube::{CustomResource, ResourceExt};
 use schemars::{
     schema::{Schema, SchemaObject},
@@ -32,13 +32,6 @@ impl AppInstance {
     pub fn namespace_any(&self) -> String {
         self.namespace().unwrap_or_default()
     }
-}
-
-// Like k8s_openapi::api::core::v1::LocalObjectReference but derives JsonSchema
-// so we can use it here.
-#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
-pub struct LocalObjectReference {
-    pub name: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]


### PR DESCRIPTION
I initially used our own LocalObjectReference definition because I didn't know I could enable the `schemars` feature on the `k8s-openapi` dependency. I enabled that feature in some past PR but I forgot to get rid of this copy.