### PR TITLE
feat: add `--docker` flag for `local apply` use 

### DIFF
--- a/tests/local_apply.rs
+++ b/tests/local_apply.rs
@@ -18,6 +18,7 @@ async fn local_apply_dry_run_script() {
             TEST_FILE,
             "--dry-run",
             "script",
+            "--docker",
             "--skip-auth",
         ])
         .unwrap()
@@ -56,6 +57,7 @@ async fn local_apply_dry_run_render() {
             TEST_FILE,
             "--dry-run",
             "render",
+            "--docker",
             "--skip-auth",
         ])
         .unwrap()


### PR DESCRIPTION
Building from https://github.com/kubecfg/kubit/pull/157, I introduced a `docker run` flow for `kubit local apply`.

I was half-way there in that I already added the `is_local` check, but didn't make this a flag for "opt-in" behaviour.

This changes that to opt-in via the `--docker` flag and has been renamed for consistency.