### PR TITLE
fix: `--diff` flag for `local apply`

### DIFF
--- a/src/local.rs
+++ b/src/local.rs
@@ -288,7 +288,7 @@ async fn prediff(
         app_instance,
         overlay_file_name,
         output,
-        dry_run,
+        &Some(DryRun::Diff),
         impersonate_user,
         docker,
         skip_auth,


### PR DESCRIPTION
In https://github.com/kubecfg/kubit/pull/177 some refactoring was done and my review missed the fact that `DryRun::Diff` is used when being passed to `write_script`, this enables the `--diff` feature to run in the correct order.

At the moment, it always drops into the regular `write_script` flow because it is not possible to pass both `--dry-run diff` and `--diff` together, so `None` is always passed to `write_script`. Thus causing the "apply" to run before the "diff" in our current flow, which is incorrect.

---

#### Before 

The changes are applied first, there is now no diff to show.

```bash
cargo run -- local apply tests/fixtures/fake-package.yml --diff
   Compiling kubit v0.0.11 (/home/influx/work/kubit)
    Finished dev [unoptimized + debuginfo] target(s) in 9.97s
     Running `target/debug/kubit local apply tests/fixtures/fake-package.yml --diff`
service/shell serverside-applied
appinstance.kubecfg.dev/test serverside-applied
statefulset.apps/shell serverside-applied
I1122 15:23:48.967594 1635146 applyset_pruner.go:149] listing objects for pruning; namespace="test", resource=kubecfg.dev/v1alpha1, Resource=appinstances
I1122 15:23:48.967594 1635146 applyset_pruner.go:149] listing objects for pruning; namespace="test", resource=apps/v1, Resource=statefulsets
I1122 15:23:48.967616 1635146 applyset_pruner.go:149] listing objects for pruning; namespace="test", resource=/v1, Resource=services
Apply? [y/N]
```

#### After 

Confirm the diff, then ask interactively.

```bash
cargo run -- local apply tests/fixtures/fake-package.yml --diff
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/kubit local apply tests/fixtures/fake-package.yml --diff`
Warning: Detected changes to resource test which is currently being deleted.
diff -u -N /tmp/LIVE-3478900336/apps.v1.StatefulSet.jdockerty.shell /tmp/MERGED-3303959222/apps.v1.StatefulSet.jdockerty.shell
--- /tmp/LIVE-3478900336/apps.v1.StatefulSet.jdockerty.shell    2023-11-22 15:22:36.642093317 +0000
+++ /tmp/MERGED-3303959222/apps.v1.StatefulSet.jdockerty.shell  2023-11-22 15:22:36.643093297 +0000
@@ -0,0 +1,55 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: "2023-11-22T15:22:36Z"
+  generation: 1
+  labels:
+    applyset.kubernetes.io/part-of: applyset-dYhPGXXb6svWIxxYV4Uipwqpgk6Z1Z9KiJ8R5Va78Ig-v1
+  name: shell
+  namespace: jdockerty
... SNIPPED
Apply? [y/N] y
service/shell serverside-applied
appinstance.kubecfg.dev/test serverside-applied
statefulset.apps/shell serverside-applied
I1122 16:02:08.716695 1681905 applyset_pruner.go:149] listing objects for pruning; namespace="test", resource=apps/v1, Resource=statefulsets
I1122 16:02:08.716735 1681905 applyset_pruner.go:149] listing objects for pruning; namespace="test", resource=/v1, Resource=services
I1122 16:02:08.716753 1681905 applyset_pruner.go:149] listing objects for pruning; namespace="test", resource=kubecfg.dev/v1alpha1, Resource=appinstances
```





