### PR TITLE
fix: use `--network host` for `kubecfg show` step

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -87,6 +87,8 @@ pub async fn emit_commandline(
                 "docker",
                 "run",
                 "--rm",
+                "--network",
+                "host",
                 "-v",
                 &format!("{}:/.kube/config", kube_config),
                 "-v",


### PR DESCRIPTION
By missing this off, you can see:

```
E1123 16:36:56.360452       1 client.go:227] couldn't get current server API group list: Get "https://0.0.0.0:51339/api?timeout=32s": dial tcp 0.0.0.0:51339: connect: connection refused
E1123 16:36:56.362520       1 client.go:227] couldn't get current server API group list: Get "https://0.0.0.0:51339/api?timeout=32s": dial tcp 0.0.0.0:51339: connect: connection refused
```

as the container is trying to find the controlplane to run against. This _eventually_ works, but is not very pretty.

The `kubectl` container already uses this, but I missed it off this one for unknown reasons.
