### PR TITLE
chore: set kodiak merge method to `squash`

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -3,5 +3,8 @@ version = 1
 [approve]
 auto_approve_usernames = ["dependabot", "renovate"]
 
+[merge]
+method = "squash"
+
 [merge.automerge_dependencies]
 usernames = ["dependabot", "renovate"]


### PR DESCRIPTION
Sets the `kodiak` [`merge.method`](https://kodiakhq.com/docs/config-reference#mergemethod) to `squash`.

When going through some of the latest commits, it's hard to see what has changed with various larger PRs. This is because kodiak is defaulting to `merge`, which is adding _every single commit_ in a PR, we can have them squash merged instead so that a PR is a single commit, regardless of size, making it simpler to thumb through changes on `main`.

Perhaps we could have a "cleanup the branch before merging" rule, but I think squash is an easy replacement for that, since they're automatically condensed and we see the PR title/number to see what changed. It's also simpler to step back over major features being merged, because its a single commit.
