### PR TITLE
fix: use `URL_SAFE` decoding mechanism for `DockerConfig`

### DIFF
--- a/src/docker_config.rs
+++ b/src/docker_config.rs
@@ -132,6 +132,26 @@ mod tests {
     }
 
     #[test]
+    fn with_auth_padding_url_safe() {
+        let src = r#"
+        {
+            "auths": {
+                "us-docker.pkg.dev": {
+                    "auth": "YUQ6QXV-Ukw="
+                }
+            }
+        }
+        "#;
+
+        let config = DockerConfig::from_str(src).expect("no errors");
+        let auth = config.get_auth("us-docker.pkg.dev").expect("no errors");
+        assert_matches!(auth, RegistryAuth::Basic(username, password) if username == "aD" && password == "Au~RL");
+
+        let auth = config.get_auth("bitnami/kubectl").expect("no errors");
+        assert_matches!(auth, RegistryAuth::Anonymous);
+    }
+
+    #[test]
     fn other_fields() {
         let src = r#"
         {

--- a/src/docker_config.rs
+++ b/src/docker_config.rs
@@ -67,7 +67,7 @@ impl DockerCredentials {
             DockerCredentials::Split { username, password } => (username, password),
 
             DockerCredentials::Composite { auth } => {
-                String::from_utf8(general_purpose::STANDARD.decode(auth)?)?
+                String::from_utf8(general_purpose::URL_SAFE.decode(auth)?)?
                     .split_once(':')
                     .map(|(a, b)| (a.to_string(), b.to_string()))
                     .ok_or(Error::MissingColon)?

--- a/src/docker_config.rs
+++ b/src/docker_config.rs
@@ -2,7 +2,6 @@ use base64::{engine::general_purpose, Engine as _};
 use oci_distribution::secrets::RegistryAuth;
 use serde::Deserialize;
 use std::collections::HashMap;
-use tracing::info;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -68,14 +67,7 @@ impl DockerCredentials {
             DockerCredentials::Split { username, password } => (username, password),
 
             DockerCredentials::Composite { auth } => {
-                let decoded_auth =
-                    general_purpose::STANDARD_NO_PAD
-                        .decode(&auth)
-                        .or_else(|_| {
-                            info!("Attempting fallback decoding");
-                            general_purpose::STANDARD.decode(&auth)
-                        })?;
-                String::from_utf8(decoded_auth)?
+                String::from_utf8(general_purpose::STANDARD.decode(auth)?)?
                     .split_once(':')
                     .map(|(a, b)| (a.to_string(), b.to_string()))
                     .ok_or(Error::MissingColon)?


### PR DESCRIPTION
We've seen a few mentions of a decoding error of a provided `.dockerconfigjson`, which has been tracked down to this `.decode` call.

I've been able to reproduce this too by using a provided config and I get back the similar error

```
Cannot launch installation job: Error decoding docker config JSON: Error decoding base64 field inside docker config auth section: Invalid padding
```

After I added this fallback, it fixes the error.

**Before:**

```
2023-12-05T12:20:27.682058Z  INFO kubit::controller: state=Idle
2023-12-05T12:20:27.714644Z  INFO kubit::controller: getting image pull credentials
2023-12-05T12:20:27.760586Z  INFO kubit::controller: status patched
2023-12-05T12:20:27.799031Z  INFO kubit::controller: status patched
2023-12-05T12:20:27.799296Z  WARN kubit::controller: reconcile failed name="influxdb" error=Error decoding docker config JSON: Error decoding base64 field inside docker config auth section: Invalid padding
```

**After:**

```
2023-12-05T12:38:10.753731Z  INFO kubit::controller: state=Idle
2023-12-05T12:38:10.763881Z  INFO kubit::controller: getting image pull credentials
2023-12-05T12:38:10.780982Z  INFO kubit::docker_config: Attempting fallback decoding
2023-12-05T12:38:12.721257Z  INFO kubit::controller: got package config
2023-12-05T12:38:12.721389Z  INFO kubit::controller: Using: ghcr.io/kubecfg/kubecfg/kubecfg:v0.34.2
```

---

~~Perhaps we should simply use `STANDARD` as the default though without this? I'm not 100% sure about specific decoding mechanisms though, so there's definitely a reason it was done like this. @mkmik Any objections/comments for this?~~

We discussed this offline and we've decided on using `URL_SAFE` as this is also used by the [`docker`](https://github.com/docker/cli/blob/f8696535e9e516a5a404661697fef6f1228ada64/cli/command/registry.go#L50-L56) CLI, so having this in alignment is a good idea.