### PR TITLE
feat: add kubectl print columns

### DIFF
--- a/kustomize/crd/bases/kubecfg.dev_appinstances.yaml
+++ b/kustomize/crd/bases/kubecfg.dev_appinstances.yaml
@@ -26,6 +26,14 @@ spec:
       jsonPath: .spec.pause
       name: paused
       type: boolean
+    - description: Latest reason emitted from the deployed package
+      jsonPath: .status.conditions[-1].reason
+      name: reason
+      type: string
+    - description: Latest status of the deployed package
+      jsonPath: .status.conditions[-1].status
+      name: status
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/kustomize/crd/bases/kubecfg.dev_appinstances.yaml
+++ b/kustomize/crd/bases/kubecfg.dev_appinstances.yaml
@@ -13,7 +13,19 @@ spec:
     singular: appinstance
   scope: Namespaced
   versions:
-  - additionalPrinterColumns: []
+  - additionalPrinterColumns:
+    - description: Image in use for the installed package
+      jsonPath: .spec.package.image
+      name: image
+      type: string
+    - description: apiVersion for the installed package
+      jsonPath: .spec.package.apiVersion
+      name: apiversion
+      type: string
+    - description: Is the AppInstance reconcillation paused?
+      jsonPath: .spec.pause
+      name: paused
+      type: boolean
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -46,6 +58,7 @@ spec:
                 - spec
                 type: object
               pause:
+                default: false
                 description: If true, the controller will not reconcile this application. You can use this if you need to do some manual changes (either with kubectl directly or with kubit CLI)
                 type: boolean
             required:

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -16,7 +16,10 @@ use serde::{Deserialize, Serialize};
     group = "kubecfg.dev",
     version = "v1alpha1",
     kind = "AppInstance",
-    namespaced
+    namespaced,
+    printcolumn = r#"{"name":"image", "type":"string", "description":"Image in use for the installed package", "jsonPath":".spec.package.image"}"#,
+    printcolumn = r#"{"name":"apiversion", "type":"string", "description":"apiVersion for the installed package", "jsonPath":".spec.package.apiVersion"}"#,
+    printcolumn = r#"{"name":"paused", "type":"boolean", "description":"Is the AppInstance reconcillation paused?", "jsonPath":".spec.pause"}"#
 )]
 #[kube(status = "AppInstanceStatus")]
 #[serde(rename_all = "camelCase")]

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -19,7 +19,9 @@ use serde::{Deserialize, Serialize};
     namespaced,
     printcolumn = r#"{"name":"image", "type":"string", "description":"Image in use for the installed package", "jsonPath":".spec.package.image"}"#,
     printcolumn = r#"{"name":"apiversion", "type":"string", "description":"apiVersion for the installed package", "jsonPath":".spec.package.apiVersion"}"#,
-    printcolumn = r#"{"name":"paused", "type":"boolean", "description":"Is the AppInstance reconcillation paused?", "jsonPath":".spec.pause"}"#
+    printcolumn = r#"{"name":"paused", "type":"boolean", "description":"Is the AppInstance reconcillation paused?", "jsonPath":".spec.pause"}"#,
+    printcolumn = r#"{"name":"reason", "type":"string", "description":"Latest reason emitted from the deployed package", "jsonPath":".status.conditions[-1].reason"}"#,
+    printcolumn = r#"{"name":"status", "type":"string", "description":"Latest status of the deployed package", "jsonPath":".status.conditions[-1].status"}"#
 )]
 #[kube(status = "AppInstanceStatus")]
 #[serde(rename_all = "camelCase")]

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -30,7 +30,6 @@ pub struct AppInstanceSpec {
     /// If true, the controller will not reconcile this application.
     /// You can use this if you need to do some manual changes (either with kubectl directly or with kubit CLI)
     #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub pause: bool,
 }
 


### PR DESCRIPTION
This adds additional printer columns for the `kubectl get` output of an `AppInstance`, making the feedback a little more clear for what has happened and could also help users quickly spot a problem with the regular output, rather than being required to always check the entire YAML input.

Before this change, the output looked like this:

```
kubectl get appinstances.kubecfg.dev -n test
NAME   AGE
test   4m34s
```

Once the additional print columns are included, this now looks like this:

```
kubectl get appinstances.kubecfg.dev
NAME   IMAGE                                   APIVERSION           PAUSED   REASON      STATUS
test   ghcr.io/kubecfg/kubit/package-demo:v1   kubit.dev/v1alpha1   false    JobFailed   False
```

---

I've also removed the minor serialisation skip on the `spec.pause` as this provides the full output for the `PAUSED` column, without it there is no value in this column, but there will be when the controller is paused. However, I think that serialising a singular boolean field is relatively trivial and providing the explicit value in here is useful for gleaning information correctly.

This isn't a dealbreaker though, we can include the `skip_serializing_if` again for reduced change radius.