### PR TITLE
fix: Remove managedFields from AppInstance

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -46,6 +46,7 @@ pub async fn run(helper: &Helper) -> Result<()> {
             let api: Api<AppInstance> = Api::namespaced(client, namespace);
             let mut app_instance = api.get(app_instance).await?;
             app_instance.status = None;
+            app_instance.metadata.managed_fields = None;
 
             let file = File::create(output)?;
             serde_json::to_writer_pretty(file, &app_instance)?;


### PR DESCRIPTION
The `kubit helpers fetch-app-instance` command is used to populate `/overlay/appinstance.json` during the apply job. This command fetches the current state of the AppInstance with the API but does not strip out managedFields. This leads to kubectl returning
`Error from server (BadRequest): metadata.managedFields must be nil` when trying to apply the manifests.

<details>
  <summary>Before</summary>

```json
{
  "apiVersion": "kubecfg.dev/v1alpha1",
  "kind": "AppInstance",
  "metadata": {
    "creationTimestamp": "2024-04-15T22:33:56Z",
    "finalizers": [
      "kubecfg.dev/appinstance-cleanup"
    ],
    "generation": 2,
    "labels": {
      "kustomize.toolkit.fluxcd.io/name": "flux-system",
      "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
    },
    "managedFields": [
      {
        "apiVersion": "kubecfg.dev/v1alpha1",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:metadata": {
            "f:labels": {
              "f:kustomize.toolkit.fluxcd.io/name": {},
              "f:kustomize.toolkit.fluxcd.io/namespace": {}
            }
          },
          "f:spec": {
            "f:imagePullSecrets": {},
            "f:package": {
              "f:apiVersion": {},
              "f:image": {},
              "f:spec": {
                "f:bar": {},
                "f:foo": {}
              }
            }
          }
        },
        "manager": "kustomize-controller",
        "operation": "Apply",
        "time": "2024-04-15T22:33:56Z"
      },
      {
        "apiVersion": "kubecfg.dev/v1alpha1",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:status": {
            "f:conditions": {},
            "f:lastLogs": {
              "f:busybox": {},
              "f:fetch-app-instance": {},
              "f:render-manifests": {}
            }
          }
        },
        "manager": "kubit",
        "operation": "Apply",
        "subresource": "status",
        "time": "2024-04-16T14:50:10Z"
      },
      {
        "apiVersion": "kubecfg.dev/v1alpha1",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:metadata": {
            "f:finalizers": {
              ".": {},
              "v:\"kubecfg.dev/appinstance-cleanup\"": {}
            }
          }
        },
        "manager": "unknown",
        "operation": "Update",
        "time": "2024-04-15T22:33:57Z"
      },
      {
        "apiVersion": "kubecfg.dev/v1alpha1",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:spec": {
            "f:pause": {}
          }
        },
        "manager": "kubectl-patch",
        "operation": "Update",
        "time": "2024-04-16T13:21:23Z"
      }
    ],
    "name": "podinfo",
    "namespace": "default",
    "resourceVersion": "6473931",
    "uid": "6d810d6a-c8cf-46ea-bb6b-e46760f057ae"
  },
  "spec": {
    "package": {
      "image": "***/podinfo:v0.0.3",
      "apiVersion": "demo/v1alpha1",
      "spec": {
        "foo": "bar",
        "bar": "baz"
      }
    },
    "imagePullSecrets": [
      {
        "name": "artifact-registry"
      }
    ],
    "pause": true
  }
}
```
</details>

<details>
  <summary>After</summary>

  ```json
{
  "apiVersion": "kubecfg.dev/v1alpha1",
  "kind": "AppInstance",
  "metadata": {
    "creationTimestamp": "2024-04-15T22:33:56Z",
    "finalizers": [
      "kubecfg.dev/appinstance-cleanup"
    ],
    "generation": 2,
    "labels": {
      "kustomize.toolkit.fluxcd.io/name": "flux-system",
      "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
    },
    "name": "podinfo",
    "namespace": "default",
    "resourceVersion": "6473931",
    "uid": "6d810d6a-c8cf-46ea-bb6b-e46760f057ae"
  },
  "spec": {
    "package": {
      "image": "***/podinfo:v0.0.3",
      "apiVersion": "demo/v1alpha1",
      "spec": {
        "bar": "baz",
        "foo": "bar"
      }
    },
    "imagePullSecrets": [
      {
        "name": "artifact-registry"
      }
    ],
    "pause": true
  }
}
  ```
</details>