### PR TITLE
ci: dont push to depot on fork

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,7 @@ jobs:
         if: github.event_name != 'pull_request'
 
       - name: Build
+        if: "!github.event.pull_request.head.repo.fork"
         uses: depot/build-push-action@e7743ee6585d261968c7ae0ef64977ee98c09d74 # v1
         with:
           project: v8n5whjnsb
@@ -75,6 +76,7 @@ jobs:
           tags: ghcr.io/kubecfg/kubit:latest
           load: true
       - name: Test
+        if: "!github.event.pull_request.head.repo.fork"
         run: |
           docker run --rm ghcr.io/kubecfg/kubit:latest --version
       - name: Push


### PR DESCRIPTION
Helps with https://github.com/kubecfg/kubit/pull/397

We run into authentication errors when forks try to build/push into
Depot as they do not originate from the kubecfg project. This also saves
the addition for everybody being added to the `kubecfg` project in order
to contribute to `kubit` :smile:

For reference, I remember [I ran into the same thing](https://github.com/kubecfg/kubecfg/pull/287) awhile back when I
first contributed to `kubecfg`, but we can also see this with `kubit`.
