### PR TITLE
chore(release): prep for `0.0.15`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "kubit"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubit"
-version = "0.0.14"
+version = "0.0.15"
 license = "MIT"
 edition = "2021"
 keywords = ["kubernetes"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This means that the installation experience is decoupled from the language of ch
 ### Kubernetes controller
 
 ```bash
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.14'
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.15'
 ```
 
 The Kubernetes controller is the main way to use kubit.
@@ -40,7 +40,7 @@ brew install kubecfg/kubit/kubit
 Direct install from sources:
 
 ```bash
-cargo install --git https://github.com/kubecfg/kubit/ --tag v0.0.14
+cargo install --git https://github.com/kubecfg/kubit/ --tag v0.0.15
 ```
 
 The CLI is an optional tool that provides helpers and alternative ways to install and inspect packages.

--- a/kustomize/manager/kustomization.yaml
+++ b/kustomize/manager/kustomization.yaml
@@ -8,4 +8,4 @@ configurations:
 images:
   - name: controller
     newName: ghcr.io/kubecfg/kubit
-    newTag: v0.0.14
+    newTag: v0.0.15


### PR DESCRIPTION
It's been awhile since we've done a release and there's a been a fix and a few niceties since `0.0.14` that we should put out there :rocket:
