### PR TITLE
fix: remove label already set in input data

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -47,6 +47,11 @@ pub async fn run(helper: &Helper) -> Result<()> {
             let mut app_instance = api.get(app_instance).await?;
             app_instance.status = None;
             app_instance.metadata.managed_fields = None;
+            app_instance
+                .metadata
+                .labels
+                .as_mut()
+                .and_then(|labels| labels.remove("applyset.kubernetes.io/part-of"));
 
             let file = File::create(output)?;
             serde_json::to_writer_pretty(file, &app_instance)?;


### PR DESCRIPTION
This fixes the following error when applying manifests:

`apply-manifests error: ApplySet label "applyset.kubernetes.io/part-of" already set in input data`

<details><summary>Before</summary>
<p>

```json
{
  "apiVersion": "kubecfg.dev/v1alpha1",
  "kind": "AppInstance",
  "metadata": {
    "creationTimestamp": "2024-04-22T15:32:01Z",
    "finalizers": [
      "kubecfg.dev/appinstance-cleanup"
    ],
    "generation": 2,
    "labels": {
      "applyset.kubernetes.io/part-of": "applyset-mBM9N2j2qchpaBrvdpdvR14sxslSY3xXQErluXJpNgE-v1",
      "kustomize.toolkit.fluxcd.io/name": "flux-system",
      "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
    },
    "name": "podinfo",
    "namespace": "default",
    "resourceVersion": "16394167",
    "uid": "52d8b18a-dc24-4d73-9086-a3a308b5da6a"
  },
  "spec": {
    "package": {
      "image": "***/podinfo:v0.0.3",
      "apiVersion": "demo/v1alpha1",
      "spec": {
        "bar": "baz",
        "foo": "bar"
      }
    },
    "imagePullSecrets": [
      {
        "name": "artifact-registry"
      }
    ],
    "pause": true
  }
}
```

</p>
</details> 

<details><summary>After</summary>
<p>

```json
{
  "apiVersion": "kubecfg.dev/v1alpha1",
  "kind": "AppInstance",
  "metadata": {
    "creationTimestamp": "2024-04-22T15:32:01Z",
    "finalizers": [
      "kubecfg.dev/appinstance-cleanup"
    ],
    "generation": 2,
    "labels": {
      "kustomize.toolkit.fluxcd.io/name": "flux-system",
      "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
    },
    "name": "podinfo",
    "namespace": "default",
    "resourceVersion": "16394167",
    "uid": "52d8b18a-dc24-4d73-9086-a3a308b5da6a"
  },
  "spec": {
    "package": {
      "image": "***/podinfo:v0.0.3",
      "apiVersion": "demo/v1alpha1",
      "spec": {
        "bar": "baz",
        "foo": "bar"
      }
    },
    "imagePullSecrets": [
      {
        "name": "artifact-registry"
      }
    ],
    "pause": true
  }
}
```

</p>
</details> 