### PR TITLE
chore(deps) pin ghcr.io/kubecfg/kubit docker to correct tag

### DIFF
--- a/kustomize/manager/kustomization.yaml
+++ b/kustomize/manager/kustomization.yaml
@@ -8,4 +8,4 @@ configurations:
 images:
   - name: controller
     newName: ghcr.io/kubecfg/kubit
-    newTag: v0.0.16@sha256:db66d1fec7961f4ef00898ecdf342bd5c6ca690ec3db23fe8b8d3e8fbc79f8cc
+    newTag: v0.0.16@sha256:d9e38e935bdb5f084bc9b1f5980987e165f7e16f0bfbef0d24d5664f9bf2c7e2


### PR DESCRIPTION
This corrects the tag for the v0.0.16 release to the correct sha, which can be found at https://github.com/kubecfg/kubit/pkgs/container/kubit/219051481?tag=v0.0.16.