### PR TITLE
chore(release): prep for `0.0.17`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "kubit"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubit"
-version = "0.0.16"
+version = "0.0.17"
 license = "MIT"
 edition = "2021"
 keywords = ["kubernetes"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This means that the installation experience is decoupled from the language of ch
 ### Kubernetes controller
 
 ```bash
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.16'
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.17'
 ```
 
 The Kubernetes controller is the main way to use kubit.
@@ -40,7 +40,7 @@ brew install kubecfg/kubit/kubit
 Direct install from sources:
 
 ```bash
-cargo install --git https://github.com/kubecfg/kubit/ --tag v0.0.16
+cargo install --git https://github.com/kubecfg/kubit/ --tag v0.0.17
 ```
 
 The CLI is an optional tool that provides helpers and alternative ways to install and inspect packages.

--- a/kustomize/manager/kustomization.yaml
+++ b/kustomize/manager/kustomization.yaml
@@ -8,4 +8,4 @@ configurations:
 images:
   - name: controller
     newName: ghcr.io/kubecfg/kubit
-    newTag: v0.0.16@sha256:d9e38e935bdb5f084bc9b1f5980987e165f7e16f0bfbef0d24d5664f9bf2c7e2
+    newTag: v0.0.17


### PR DESCRIPTION
We need a new release that incorporates #458.
