### PR TITLE
fix: kubit-applier SA needs CRD delete permission

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -726,65 +726,25 @@ impl AppInstanceLike {
         let role: Api<ClusterRole> = Api::all(ctx.client.clone());
         let res = ClusterRole {
             metadata: metadata.clone(),
-            rules: Some(vec![
-                PolicyRule {
-                    api_groups: Some(
-                        ["rbac.authorization.k8s.io"]
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect(),
-                    ),
-                    resources: Some(
-                        ["clusterroles", "clusterrolebindings"]
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect(),
-                    ),
-                    verbs: ["delete", "create", "patch", "list", "get"]
+            rules: Some(vec![PolicyRule {
+                api_groups: Some(
+                    ["apiextensions.k8s.io"]
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
-                    ..Default::default()
-                },
-                PolicyRule {
-                    api_groups: Some(
-                        ["apiextensions.k8s.io"]
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect(),
-                    ),
-                    resources: Some(
-                        ["customresourcedefinitions"]
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect(),
-                    ),
-                    verbs: ["delete", "create", "patch", "list", "get"]
+                ),
+                resources: Some(
+                    ["customresourcedefinitions"]
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
-                    ..Default::default()
-                },
-                PolicyRule {
-                    api_groups: Some(
-                        ["influxdata.io"]
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect(),
-                    ),
-                    resources: Some(
-                        ["*"]
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect(),
-                    ),
-                    verbs: ["watch", "update", "delete", "create", "patch", "list", "get"]
-                        .iter()
-                        .map(|s| s.to_string())
-                        .collect(),
-                    ..Default::default()
-                },
-            ]),
+                ),
+                verbs: ["delete", "create", "patch", "list", "get"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                ..Default::default()
+            }]),
             ..Default::default()
         };
         role.patch(&res.name_any(), &pp, &Patch::Apply(&res))


### PR DESCRIPTION
In order to delete CRDs that it creates (ie when doing cleanup finalization for an AppInstance), `kubit-applier` needs delete permission.
```
kubit-cleanup-influxdb-c8g6l cleanup-manifests error: pruning CustomResourceDefinition.apiextensions.k8s.io licenses.influxdata.io: customresourcedefinitions.apiextensions.k8s.io "licenses.influxdata.io" is forbidden: User "system:serviceaccount:influxdb:kubit-applier" cannot delete resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

This PR adds the necessary `delete` permission to the existing `ClusterRole`. It also renames some functions and moves their calling location as a bit of added cleanup.
