### PR TITLE
docs: add short note for release process

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,8 @@
+# A new release :rocket:
+
+1. Prepare the various text files with a bump to a new version, an example is shown [here](https://github.com/kubecfg/kubit/pull/479).
+1. Ensure you have the latest changes available after a merge to `main`.
+1. Create your desired tag with `git tag` or equivalent.
+  a. **Reminder:** `kubit` uses [semver](https://semver.org/).
+1. Push the newly created tag using `git push origin <tag>` or equivalent.
+1. CI will create a [draft release](https://github.com/kubecfg/kubit/releases) for the new tag. Now curate some notes and publish the release!

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,8 +1,11 @@
 # A new release :rocket:
 
-1. Prepare the various text files with a bump to a new version, an example is shown [here](https://github.com/kubecfg/kubit/pull/479).
-1. Ensure you have the latest changes available after a merge to `main`.
+1. Prepare the various text files with a bump to a new version.
+You can utilise the helper script in `scripts/prepare_release.sh <DESIRED_VERSION>` for this purpose.
+E.g. `scripts/prepare_release.sh 0.0.19`
+1. Create a pull request with the newly prepared files.
+1. Ensure you have the latest changes available after a merge to `main` from the changes above.
 1. Create your desired tag with `git tag` or equivalent.
-  a. **Reminder:** `kubit` uses [semver](https://semver.org/).
+**Reminder:** `kubit` uses [semver](https://semver.org/). E.g. `git tag v0.0.19`
 1. Push the newly created tag using `git push origin <tag>` or equivalent.
-1. CI will create a [draft release](https://github.com/kubecfg/kubit/releases) for the new tag. Now curate some notes and publish the release!
+1. CI will create a [draft release](https://github.com/kubecfg/kubit/releases) for the new tag. Curate some notes and publish the release!

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+latest_tag=$(git describe --tags --abbrev=0)
+echo "Latest tag: ${latest_tag}"
+
+# Removing the proceeding v as this is not used everywhere.
+# E.g. Cargo.toml uses the plain version number.
+latest_version=${latest_tag//v}
+echo "Latest version: ${latest_version}"
+
+desired_version=$1
+
+if [ -z $1 ]; then
+    echo -e "\ndesired_version is required\n"
+    echo -e "For example: prepare_release.sh 0.0.19\n"
+    exit 1
+fi
+
+echo "Desired version: ${desired_version}"
+
+# The lock file is excluded so that we do not manipulate it directly.
+# Allow `cargo` to do this instead for safety.
+grep \
+    -r \
+    --exclude-dir={target,.git} \
+    --exclude="Cargo.lock" \
+    -l "${latest_version}" | \
+    xargs sed -i "s/${latest_version}/${desired_version}/" \
+    && cargo check


### PR DESCRIPTION
Closes https://github.com/kubecfg/kubit/issues/483

Adds some short notes on how someone can conduct a release of `kubit`.
