### PR TITLE
fix: add missing kubit-applier permissions

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -728,16 +728,20 @@ impl AppInstanceLike {
             metadata: metadata.clone(),
             rules: Some(vec![PolicyRule {
                 api_groups: Some(
-                    ["apiextensions.k8s.io"]
+                    ["apiextensions.k8s.io", "rbac.authorization.k8s.io"]
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
                 ),
                 resources: Some(
-                    ["customresourcedefinitions"]
-                        .iter()
-                        .map(|s| s.to_string())
-                        .collect(),
+                    [
+                        "customresourcedefinitions",
+                        "clusterrolebindings",
+                        "clusterroles",
+                    ]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
                 ),
                 verbs: ["delete", "create", "patch", "list", "get"]
                     .iter()


### PR DESCRIPTION


>[!NOTE]
>We need to consider permission creep here, as `kubit` is gaining a tonne of administrative ability within clusters, perhaps this is inevitable given it's role as a installation mechanism/helper.

As part of the pruning done by the applyset job, there are some missing permissions. Note that this does **NOT** affect `kubit`'s ability to apply changes, but leave orphaned resources if not fixed, as `kubit` would not be able to delete them.

```
error: listing rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding objects for pruning: clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:influxdb:kubit-applier" cannot list resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope
```

Once `clusterrolebindings` are added, we run into similar for the `clusterrole` group:
```
error: listing rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding objects for pruning: clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:influxdb:kubit-applier" cannot list resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope
```

