### PR TITLE
fix: tag for single-namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This has a few advantages:
 To use `kubit` in single namespace mode, install the `single-namespace` flavor of the `kustomize` package into a specific namespace:
 
 ```
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/single-namespace?ref=v0.0.13' -n <my-application-namespace>
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/single-namespace?ref=v0.0.18' -n <my-application-namespace>
 ```
 
 This instance of `kubit` is then configured by creating a `ConfigMap` named `app-instance` with the `data` field containing a key `app-instance` with the yaml


### PR DESCRIPTION
I suspect that this has been wrong for awhile since it got left behind, so any `sed -i ...` usage would have missed it too when going from `0.0.14` to `0.0.15` and so forth.

With this aligned, further releases will also bump this tag too :+1: 