### PR TITLE
chore: prepare for `0.0.19`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "kubit"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubit"
-version = "0.0.18"
+version = "0.0.19"
 license = "MIT"
 edition = "2021"
 keywords = ["kubernetes"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This means that the installation experience is decoupled from the language of ch
 ### Kubernetes controller
 
 ```bash
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.18'
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/global?ref=v0.0.19'
 ```
 
 The Kubernetes controller is the main way to use kubit.
@@ -40,7 +40,7 @@ brew install kubecfg/kubit/kubit
 Direct install from sources:
 
 ```bash
-cargo install --git https://github.com/kubecfg/kubit/ --tag v0.0.18
+cargo install --git https://github.com/kubecfg/kubit/ --tag v0.0.19
 ```
 
 The CLI is an optional tool that provides helpers and alternative ways to install and inspect packages.
@@ -146,7 +146,7 @@ This has a few advantages:
 To use `kubit` in single namespace mode, install the `single-namespace` flavor of the `kustomize` package into a specific namespace:
 
 ```
-kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/single-namespace?ref=v0.0.18' -n <my-application-namespace>
+kubectl apply -k 'https://github.com/kubecfg/kubit//kustomize/single-namespace?ref=v0.0.19' -n <my-application-namespace>
 ```
 
 This instance of `kubit` is then configured by creating a `ConfigMap` named `app-instance` with the `data` field containing a key `app-instance` with the yaml

--- a/kustomize/manager/kustomization.yaml
+++ b/kustomize/manager/kustomization.yaml
@@ -8,4 +8,4 @@ configurations:
 images:
   - name: controller
     newName: ghcr.io/kubecfg/kubit
-    newTag: v0.0.18
+    newTag: v0.0.19


### PR DESCRIPTION
The new preparation script works very nicely here too, great convenience :rocket: 

```
scripts/prepare_release.sh 0.0.19
Latest tag: v0.0.18
Latest version: 0.0.18
Desired version: 0.0.19
     Locking 1 package to latest compatible version
    Updating kubit v0.0.18 (/home/influx/work/kubit) -> v0.0.19
  Downloaded tower-layer v0.3.3
...more cargo things
```