### PR TITLE
fix: enable single-namespace mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
 FROM lukemathwalker/cargo-chef:latest-rust-1.75.0@sha256:486ca13b5d6ef4ad2ae21022be903487e502ea7f860bb5b7c8a0ee9a17dfa4c6 AS chef
-WORKDIR app
+WORKDIR /app
 
 FROM chef AS planner
 COPY . .
@@ -20,6 +20,6 @@ FROM debian:bookworm-slim@sha256:ad86386827b083b3d71139050b47ffb32bbd9559ea9b134
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-WORKDIR app
+WORKDIR /app
 COPY --from=builder /app/target/release/kubit /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/kubit"]

--- a/kustomize/single-namespace/kustomization.yaml
+++ b/kustomize/single-namespace/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../crd
   - ../no-crd

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -854,7 +854,9 @@ impl AppInstanceLike {
 
     async fn launch_job(&self, ctx: &Context) -> Result<()> {
         self.setup_namespaced_roles(ctx).await?;
-        self.setup_cluster_roles(ctx).await?;
+        if ctx.config_map_name.is_none() {
+            self.setup_cluster_roles(ctx).await?;
+        }
 
         let package_config: PackageConfig = self.fetch_package_config(ctx).await?;
         info!("got package config");


### PR DESCRIPTION
This implements some fixes for the single-namespace mode. The original behavior attempts to install the CustomResourceDefinition and ClusterRoles regardless of whether kubit is running in single-namespace mode. Since these require "root" scoped permissions, this would prevent kubit from applying the app-instance ConfigMap.