### PR TITLE
fix: migrate from bitnami/kubectl:1.27.5 to registry.k8s.io/kubectl:v1.28.0

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -5,7 +5,7 @@ use std::env;
 
 pub const KUBIT_APPLIER_FIELD_MANAGER: &str = "kubit-applier";
 /// Image used within the "apply" step of kubit
-pub const DEFAULT_APPLY_KUBECTL_IMAGE: &str = "bitnami/kubectl:1.27.5";
+pub const DEFAULT_APPLY_KUBECTL_IMAGE: &str = "registry.k8s.io/kubectl:v1.28.0";
 pub const KUBECTL_APPLYSET_ENABLED: &str = "KUBECTL_APPLYSET=true";
 
 /// Generates shell script that will apply the manifests and writes it to w


### PR DESCRIPTION
This updates the default kubectl image for the apply step from `bitnami/kubectl:1.27.5` to `registry.k8s.io/kubectl:v1.28.0` because the bitnami images are no longer available since https://github.com/bitnami/charts/issues/35164.

The `registry.k8s.io/kubectl:v1.28.0` image is already the default kubectl image for the render step.