### PR TITLE
fix(ci): repair three bit-rotted CI failures

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,13 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Install action-validator with asdf
-        uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
-        with:
-          tool_versions: |
-            action-validator 0.6.0
-
       - name: Lint Actions
         run: |
+          npm install -g @action-validator/cli@0.6.0
           find .github/workflows -type f \( -iname \*.yaml -o -iname \*.yml \) \
-            | xargs -I {} action-validator --verbose {}
+            | xargs -I {} action-validator {}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,9 @@ jobs:
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: "kubit-test-cluster-1"
+          # The action's default (v5.4.6) predates the checksums.txt that the
+          # current install.sh requires, so installing it 404s.
+          k3d-version: v5.8.3
       - name: Run all tests
         run: cargo test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
-FROM lukemathwalker/cargo-chef:latest-rust-1.75.0@sha256:486ca13b5d6ef4ad2ae21022be903487e502ea7f860bb5b7c8a0ee9a17dfa4c6 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.79.0@sha256:d49136dce690e5e00dec600d4165f5720624d6dc7f8c1016effe53d060560ec0 AS chef
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
CI has been red on every PR for months. Investigating turned up three
independent, unrelated causes — all external bit-rot, none of them caused by
a change in this repo.

`main` itself hasn't been pushed since 2026-05-22, so every signal came from
renovate PRs. This PR is the first real exercise of these workflows in months.

### `Check actions` — broken on *every* push

`asdf-vm/actions/install` clones asdf `master`, which is now the Go rewrite and
no longer ships a `bin/asdf` script, so the step fails with *"Unable to locate
executable file: asdf"*.

Installs `action-validator` from npm instead — same pinned 0.6.0. The npm build
doesn't accept `--verbose`, so that flag is dropped. All three workflow files
validate clean with it.

### `integration_tests` — 404 installing k3d

`k3d-action` fetches `install.sh` from k3d `main` (always latest) but defaults to
k3d **v5.4.6** (2022). The current `install.sh` requires a `checksums.txt`
release asset that v5.4.6 never published → 404 → `curl` exits 22.

Pinned `k3d-version: v5.8.3`, whose `checksums.txt` contains the
`_dist/k3d-linux-amd64` entry the script greps for.

### `pack` — Rust too old for lockfile v4

The Dockerfile pinned cargo-chef at Rust **1.75**, which can't read `Cargo.lock`
v4 (needs ≥ 1.78), so *any* renovate lockfile bump broke the image build with
`failed to parse lock file`. It was also inconsistent with `rust-toolchain.toml`,
which pins 1.79.

Bumped the base image to `latest-rust-1.79.0` to match. Verified against the real
failing branch's `Cargo.toml` + `Cargo.lock`:

| | 1.75 (old) | 1.79 (new) |
|---|---|---|
| renovate lock v4 | `failed to parse lock file` — exact CI error | `PARSE OK` |
| main lock v3 | ok | ok, no rewrite under `--locked` |

### Not addressed

`src/controller.rs:533` has a redundant `&` that clippy 1.97 rejects. CI passes
today because `rust-toolchain.toml` pins 1.79 — it'll only bite when the
toolchain is bumped. Left alone to keep this PR scoped to the actual failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)