### PR TITLE
chore: bump Rust toolchain 1.79 -> 1.97

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
-FROM lukemathwalker/cargo-chef:latest-rust-1.79.0@sha256:d49136dce690e5e00dec600d4165f5720624d6dc7f8c1016effe53d060560ec0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.97.1-bookworm@sha256:1689f62cfaa6603480356923cb5966544b2dd6ea523e30486bee4f149965d5bc AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.79"
+channel = "1.97"
 components = ["rustfmt", "clippy"]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -530,7 +530,7 @@ impl AppInstanceLike {
 
     async fn launch_cleanup_job(&self, ctx: &Context) -> Result<()> {
         let ns = &self.instance.namespace().ok_or(Error::NamespaceRequired)?;
-        let cleanup_job_name = format!("kubit-cleanup-{}", &self.name_any());
+        let cleanup_job_name = format!("kubit-cleanup-{}", self.name_any());
 
         let mut volumes = vec![Volume {
             name: "manifests".to_string(),

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -68,12 +68,12 @@ pub async fn run(helper: &Helper) -> Result<()> {
 
             let data = cm.data.ok_or(anyhow::anyhow!(
                 "ConfigMap {} did not have a data field",
-                &config_map
+                config_map
             ))?;
 
             let app_instance = data.get("app-instance").ok_or(anyhow::anyhow!(
                 "ConfigMap {} data did not have an app-instance field",
-                &config_map
+                config_map
             ))?;
 
             let ai: AppInstance = serde_yaml::from_str(app_instance)?;


### PR DESCRIPTION
## Why

Dependencies have started shipping edition 2024 manifests, which Cargo 1.79 cannot parse **at all** — it fails before compiling a single line:

```
error: failed to parse manifest at .../clap_builder-4.6.6/Cargo.toml
Caused by:
  feature `edition2024` is required
  ... not stabilized in this version of Cargo (1.79.0)
```

This is what's blocking #595 (Renovate's clap `4.5.21` -> `4.6.6` lockfile bump), in both failing jobs:

- `build` — at the Lint step, toolchain from `rust-toolchain.toml`
- `pack` — at `cargo chef cook`, toolchain from the `cargo-chef` base image

Any future Renovate bump that pulls in an edition-2024 crate hits the same wall, so this is worth fixing on its own rather than inside a dependency PR.

## What

- `rust-toolchain.toml`: `1.79` -> `1.97`
- `Dockerfile`: cargo-chef base image -> `latest-rust-1.97.1-bookworm`. Explicitly the **bookworm** variant so the produced binary stays glibc-compatible with the `debian:bookworm-slim` runtime stage (the plain tag now tracks trixie).
- `src/controller.rs`: fixes the single new clippy lint the bump surfaces (`clippy::useless_borrows_in_formatting`).

The crate's own `edition = "2021"` is **unchanged** — nothing requires bumping it, and migrating to edition 2024 is an independent decision.

## Verification

Ran the full `build` job gate locally: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, manifest regeneration + no-diff check, and `cargo test --lib` (16 passed). Also applied #595's `Cargo.lock` on top of this branch and confirmed `cargo clippy --locked -- -D warnings` passes with clap 4.6.6, i.e. this genuinely unblocks that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)